### PR TITLE
ops: extend CI structural check to include P0 domain canons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
             knowledge/governance/AGENT_POLICY.md \
             knowledge/architecture/ARCHITECTURE_OVERVIEW.md \
             knowledge/SYSTEM_INVARIANTS.md \
-            knowledge/project/PROJECT_META.md; do
+            knowledge/project/PROJECT_META.md \
+            knowledge/project/CLAIMS_FRAMEWORK.md \
+            knowledge/project/SAFETY_PLAYBOOK.md \
+            knowledge/project/PRIVACY_BY_DESIGN.md; do
             if [ -s "$f" ]; then
               echo "OK: $f"
             else


### PR DESCRIPTION
## Scope

Post-merge follow-up nach PR #16 + PR #17.

PR #17 führte den CI-Strukturcheck ein. Zum Zeitpunkt von PR #17 lagen die P0-Domain-Canon-Dateien noch nicht auf main. Mit Merge von PR #16 existieren sie jetzt – der Strukturcheck muss sie abdecken.

## Änderung

`ci.yml`: Drei P0-Domain-Canon-Dateien in die Pflichtdatei-Prüfung aufgenommen:
- `knowledge/project/CLAIMS_FRAMEWORK.md`
- `knowledge/project/SAFETY_PLAYBOOK.md`
- `knowledge/project/PRIVACY_BY_DESIGN.md`

Strukturcheck prüft jetzt 13 Pflichtdateien.

## Warum

Diese Dateien sind P0-Canon. Wenn sie gelöscht oder geleert werden, soll CI fehlschlagen. Das ist das exakte Ziel des Strukturchecks.

## Checks

- Alle 13 Dateien existieren auf main (nach PR #16 Merge)
- Kein Scope-Creep, keine neuen Dateien
- Nur relevante Datei gestaged, kein `git add .`