### PR TITLE
feat(harness): add runtime inspect audits and operator tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist/
 harness/data/*.db
 harness/data/*.db-wal
 harness/data/*.db-shm
+harness/data/*.pid

--- a/harness/README.md
+++ b/harness/README.md
@@ -64,6 +64,68 @@ python -m harness.inspect_events --session harness-abc123
 Alle Skripte schreiben in `harness/data/events.db` (gitignored).
 Exit-Code 0 = ohne Ausnahme abgeschlossen; 1 = mindestens ein Fehler.
 
+### Minimaler Runtime-Entrypoint
+
+Für den kleinsten deploybaren Mono-Prozess gibt es zusätzlich:
+
+```bash
+python -m harness.runtime_server \
+  --db /absolute/path/events.db \
+  --log /absolute/path/runtime.log \
+  --host 127.0.0.1 \
+  --port 8080
+```
+
+Eigenschaften:
+- `--db` ist Pflicht und muss absolut sein; kein Fallback auf `harness/data/events.db`
+- `--log` ist Pflicht und muss absolut sein; kein Fallback ins Workdir
+- Reachability: `GET /health`
+- Session-Start: `POST /v1/sessions`
+- Turn-Verarbeitung: `POST /v1/turns`
+- Stop-Pfad: `Ctrl+C` / `SIGTERM` -> sauberer Shutdown mit `EventStore.close()`
+- Default ohne Adapter: fehlender Provider fuehrt im Reflexionspfad kontrolliert zu fail-closed (`NO_ADAPTER_CONFIGURED`)
+
+Auch dieser Entrypoint ist noch kein Hetzner-Nachweis und keine Pilot-Evidence.
+
+### Reproduzierbare Runtime-Tooling-Pfade
+
+Für Start / Stop / Health / Inspect gibt es zusätzlich:
+
+```bash
+# Start im Hintergrund, schreibt PID-Metadaten an expliziten Pfad
+python -m harness.runtime_tools start \
+  --db /absolute/path/events.db \
+  --log /absolute/path/runtime.log \
+  --pid-file /absolute/path/runtime.pid \
+  --host 127.0.0.1 \
+  --port 8080
+
+# Reachability prüfen
+python -m harness.runtime_tools health --host 127.0.0.1 --port 8080
+
+# SQLite-Store gegen expliziten Pfad prüfen
+python -m harness.runtime_tools inspect-db --db /absolute/path/events.db --check-only
+
+# Runtime-Log gegen expliziten Pfad prüfen
+python -m harness.runtime_tools inspect-log --log /absolute/path/runtime.log --check-only
+
+# Sidepath- / Shadow-Store-Scan für Zielverzeichnis + Workdir
+python -m harness.runtime_tools inspect-sidepaths \
+  --db /absolute/path/events.db \
+  --log /absolute/path/runtime.log \
+  --pid-file /absolute/path/runtime.pid \
+  --workdir /absolute/path/workdir
+
+# Sauber stoppen; prüft danach auch auf verbleibende -wal / -shm Dateien
+python -m harness.runtime_tools stop --pid-file /absolute/path/runtime.pid
+```
+
+Grenzen:
+- auch dieses Tooling ist kein Hetzner-Nachweis
+- `inspect-db` und `inspect-log` akzeptieren nur explizite absolute Pfade
+- `inspect-sidepaths` scannt nur die explizit benannten Roots; keine impliziten Fallback-Pfade
+- das Stop-Tooling nutzt nur lokale Kontrollpfade; keine Remote-Orchestrierung
+
 ---
 
 ## Testfall-Abdeckung
@@ -91,6 +153,12 @@ Exit-Code 0 = ohne Ausnahme abgeschlossen; 1 = mindestens ein Fehler.
 | T19 | Malformed Output → fail-closed → EXIT        | Fault-Injection      | ausführbar         |
 | T20 | Adapter-Exception → fail-closed → EXIT       | Fault-Injection lok. | ausführbar (lokal) |
 | T21 | GUARD_BLOCK → User-Retry → REFLECTION        | Stub-Adapter         | ausführbar         |
+
+Wichtig: Die Harness-Szenario-IDs sind kein 1:1-Abbild aller
+Baseline-IDs. Insbesondere ist Harness-`T21` nicht identisch mit
+Baseline-`T21` aus `knowledge/ops/PROMPT_TEST_BASELINE.md`
+(Hetzner-/SQLite-Sidepath-Check). Die kanonische Zuordnung steht in
+`PROMPT_TEST_BASELINE.md` §3.2.
 
 Providergekoppelte Fälle (T10, T12) bleiben `blockiert` bis TB-2 freigegeben ist.
 

--- a/harness/event_store.py
+++ b/harness/event_store.py
@@ -92,7 +92,8 @@ class EventStore:
         }
         for key, val in kwargs.items():
             if key in _ALLOWED_FIELDS and val is not None:
-                row[key] = str(val)
+                # Persist canonical enum values instead of Enum repr strings.
+                row[key] = str(val.value) if hasattr(val, "value") else str(val)
 
         cols = ", ".join(row.keys())
         placeholders = ", ".join(["?"] * len(row))

--- a/harness/inspect_events.py
+++ b/harness/inspect_events.py
@@ -2,11 +2,10 @@
 Event Store Inspector — Traumtänzer Evidence Harness
 
 Reads the local SQLite event store and prints a structured summary.
-Also performs a leak/sidepath check: verifies no forbidden content
-field is present in the schema or any row.
+Also performs schema and row-value audits for redacted runtime events.
 
-Exit code 0 = store readable, no schema violations found.
-Exit code 1 = store not found, unreadable, or schema violation detected.
+Exit code 0 = store readable, no DB audit violations found.
+Exit code 1 = store not found, unreadable, or DB audit violation detected.
 
 HARNESS-ONLY. Not for live user sessions.
 
@@ -17,11 +16,15 @@ Usage:
 
 import argparse
 import logging
+import os
 import sqlite3
 import sys
+from datetime import datetime
 from pathlib import Path
 
 from .event_store import DEFAULT_DB_PATH, _FORBIDDEN_FIELDS, _ALLOWED_FIELDS
+from .guards import GuardCategory, InputDecision, OutputDecision, ViolationType
+from .kernel import S
 
 logging.basicConfig(
     level=logging.INFO,
@@ -29,6 +32,98 @@ logging.basicConfig(
     datefmt="%H:%M:%S",
 )
 logger = logging.getLogger(__name__)
+
+_BASE_EVENT_COLUMNS = frozenset({"id", "session_id", "event_type", "timestamp"})
+_KNOWN_EVENT_TYPES = frozenset({
+    "SESSION_STARTED",
+    "SESSION_ENDED",
+    "INPUT_GUARD_RESULT",
+    "OUTPUT_GUARD_RESULT",
+    "SAFE_STATE_TRANSITION",
+    "SYSTEM_ERROR",
+})
+_STATE_VALUES = frozenset({
+    S.ENTRY,
+    S.CHECK_IN,
+    S.REFLECTION,
+    S.PAUSED,
+    S.EXIT,
+    S.EXTERNAL_REFERRAL,
+    S.GUARD_BLOCK,
+})
+_INPUT_DECISION_VALUES = frozenset(decision.value for decision in InputDecision)
+_OUTPUT_DECISION_VALUES = frozenset(decision.value for decision in OutputDecision)
+_GUARD_CATEGORY_VALUES = frozenset(category.value for category in GuardCategory)
+_VIOLATION_TYPE_VALUES = frozenset(violation.value for violation in ViolationType)
+_TRIGGER_EVENT_VALUES = frozenset({
+    "USER_OPT_IN",
+    "USER_CONFIRMED",
+    "USER_GO",
+    "USER_RETRY",
+    "BLOCK_EXIT",
+    "BLOCK_REFER",
+    "BLOCK_PAUSE",
+    "BLOCK_BOUNDARY",
+    "OUTPUT_GUARD_RESULT",
+    "ERROR_FAIL_CLOSED",
+})
+_END_TYPE_VALUES = frozenset({
+    "NORMAL",
+    "SAFEWORD",
+    "GUARD_ABORT",
+    "REFERRAL",
+    "SYSTEM_ERROR",
+})
+_ERROR_CODE_VALUES = frozenset({
+    "GUARD_ERROR",
+    "OUTPUT_GUARD_ERROR",
+    "NO_ADAPTER_CONFIGURED",
+    "ADAPTER_EXCEPTION",
+    "EMPTY_OR_INVALID_PROVIDER_OUTPUT",
+    "UNKNOWN_STATE",
+})
+_COMPONENT_VALUES = frozenset({"GUARD", "KERNEL", "LLM_ADAPTER"})
+_EVENT_ALLOWED_FIELDS: dict[str, frozenset[str]] = {
+    "SESSION_STARTED": frozenset(),
+    "SESSION_ENDED": frozenset({"end_type", "last_state"}),
+    "INPUT_GUARD_RESULT": frozenset({"decision", "guard_category"}),
+    "OUTPUT_GUARD_RESULT": frozenset({"decision", "violation_type"}),
+    "SAFE_STATE_TRANSITION": frozenset({"from_state", "to_state", "trigger_event"}),
+    "SYSTEM_ERROR": frozenset({"error_code", "component"}),
+}
+_EVENT_REQUIRED_FIELDS: dict[str, frozenset[str]] = {
+    "SESSION_STARTED": frozenset(),
+    "SESSION_ENDED": frozenset({"end_type", "last_state"}),
+    "INPUT_GUARD_RESULT": frozenset({"decision", "guard_category"}),
+    "OUTPUT_GUARD_RESULT": frozenset({"decision"}),
+    "SAFE_STATE_TRANSITION": frozenset({"from_state", "to_state", "trigger_event"}),
+    "SYSTEM_ERROR": frozenset({"error_code", "component"}),
+}
+_EVENT_FIELD_ALLOWED_VALUES: dict[tuple[str, str], frozenset[str]] = {
+    ("SESSION_ENDED", "end_type"): _END_TYPE_VALUES,
+    ("SESSION_ENDED", "last_state"): _STATE_VALUES,
+    ("INPUT_GUARD_RESULT", "decision"): _INPUT_DECISION_VALUES,
+    ("INPUT_GUARD_RESULT", "guard_category"): _GUARD_CATEGORY_VALUES,
+    ("OUTPUT_GUARD_RESULT", "decision"): _OUTPUT_DECISION_VALUES,
+    ("OUTPUT_GUARD_RESULT", "violation_type"): _VIOLATION_TYPE_VALUES,
+    ("SAFE_STATE_TRANSITION", "from_state"): _STATE_VALUES,
+    ("SAFE_STATE_TRANSITION", "to_state"): _STATE_VALUES,
+    ("SAFE_STATE_TRANSITION", "trigger_event"): _TRIGGER_EVENT_VALUES,
+    ("SYSTEM_ERROR", "error_code"): _ERROR_CODE_VALUES,
+    ("SYSTEM_ERROR", "component"): _COMPONENT_VALUES,
+}
+_SIDEPATH_SUFFIXES = frozenset({".log", ".jsonl", ".txt", ".ndjson", ".dump"})
+_SIDEPATH_NAME_MARKERS = (
+    "debug",
+    "dump",
+    "payload",
+    "prompt",
+    "transcript",
+    "shadow",
+    "sidepath",
+    "export",
+)
+_SIDEPATH_SKIP_DIRS = frozenset({".git", "__pycache__", ".venv", "node_modules", "build", "dist"})
 
 
 # ---------------------------------------------------------------------------
@@ -50,12 +145,153 @@ def check_sidepath_columns(conn: sqlite3.Connection) -> list[str]:
     Sidepath check: any column not in the known allowed set
     (excluding id, session_id, event_type, timestamp) is unexpected.
     """
-    known = _ALLOWED_FIELDS | {"id", "session_id", "event_type", "timestamp"}
+    known = _ALLOWED_FIELDS | _BASE_EVENT_COLUMNS
     violations: list[str] = []
     cols = [row[1] for row in conn.execute("PRAGMA table_info(events)").fetchall()]
     for col in cols:
         if col not in known:
             violations.append(f"Unexpected column (possible sidepath): {col!r}")
+    return violations
+
+
+def _select_event_rows(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    conn.row_factory = sqlite3.Row
+    return conn.execute(
+        """SELECT id, session_id, event_type, timestamp,
+                  decision, guard_category, violation_type,
+                  from_state, to_state, trigger_event,
+                  end_type, last_state, error_code, component
+           FROM events
+           ORDER BY id"""
+    ).fetchall()
+
+
+def _valid_session_id(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    if not (4 <= len(value) <= 128):
+        return False
+    if any(ch.isspace() for ch in value):
+        return False
+    return all(ch.isalnum() or ch in "-_:.@" for ch in value)
+
+
+def _valid_timestamp(value: object) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    try:
+        datetime.fromisoformat(value)
+    except ValueError:
+        return False
+    return True
+
+
+def check_row_values(conn: sqlite3.Connection) -> list[str]:
+    violations: list[str] = []
+    rows = _select_event_rows(conn)
+
+    for row in rows:
+        row_id = row["id"]
+        event_type = row["event_type"]
+        if event_type not in _KNOWN_EVENT_TYPES:
+            violations.append(f"Row {row_id}: unknown event_type={event_type!r}")
+            continue
+
+        if not _valid_session_id(row["session_id"]):
+            violations.append(f"Row {row_id}: invalid session_id format")
+
+        if not _valid_timestamp(row["timestamp"]):
+            violations.append(f"Row {row_id}: invalid timestamp format")
+
+        allowed_fields = _EVENT_ALLOWED_FIELDS[event_type]
+        required_fields = _EVENT_REQUIRED_FIELDS[event_type]
+
+        for field in _ALLOWED_FIELDS:
+            value = row[field]
+            if field in required_fields and (value is None or str(value).strip() == ""):
+                violations.append(f"Row {row_id}: missing required field {field!r} for {event_type}")
+                continue
+
+            if value is None:
+                continue
+
+            if field not in allowed_fields:
+                violations.append(
+                    f"Row {row_id}: unexpected non-null field {field!r} for {event_type}"
+                )
+                continue
+
+            allowed_values = _EVENT_FIELD_ALLOWED_VALUES.get((event_type, field))
+            if allowed_values and str(value) not in allowed_values:
+                violations.append(
+                    f"Row {row_id}: invalid {field}={value!r} for {event_type}"
+                )
+
+        if event_type == "OUTPUT_GUARD_RESULT":
+            decision = row["decision"]
+            violation_type = row["violation_type"]
+            if decision == OutputDecision.BLOCK.value and violation_type is None:
+                violations.append(f"Row {row_id}: BLOCK output decision without violation_type")
+            if decision != OutputDecision.BLOCK.value and violation_type is not None:
+                violations.append(
+                    f"Row {row_id}: non-BLOCK output decision with violation_type present"
+                )
+
+    return violations
+
+
+def collect_db_audit_violations(conn: sqlite3.Connection) -> list[str]:
+    return check_schema(conn) + check_sidepath_columns(conn) + check_row_values(conn)
+
+
+def scan_sidepaths(
+    roots: list[Path],
+    *,
+    allowed_paths: set[Path] | None = None,
+) -> list[str]:
+    violations: list[str] = []
+    allowed = {path.resolve(strict=False) for path in (allowed_paths or set())}
+    seen_roots: set[Path] = set()
+
+    for root in roots:
+        resolved_root = root.resolve(strict=False)
+        if resolved_root in seen_roots:
+            continue
+        seen_roots.add(resolved_root)
+
+        if not resolved_root.exists():
+            violations.append(f"Scan root missing: {resolved_root}")
+            continue
+        if not resolved_root.is_dir():
+            violations.append(f"Scan root is not a directory: {resolved_root}")
+            continue
+
+        for current, dirnames, filenames in os.walk(resolved_root):
+            dirnames[:] = [
+                name for name in dirnames
+                if name not in _SIDEPATH_SKIP_DIRS
+            ]
+            current_path = Path(current)
+            for filename in filenames:
+                candidate = (current_path / filename).resolve(strict=False)
+                if candidate in allowed:
+                    continue
+
+                lower_name = candidate.name.lower()
+                suffix = candidate.suffix.lower()
+                if suffix not in _SIDEPATH_SUFFIXES and not any(
+                    marker in lower_name for marker in _SIDEPATH_NAME_MARKERS
+                ):
+                    continue
+
+                try:
+                    rel_path = candidate.relative_to(resolved_root)
+                except ValueError:
+                    rel_path = candidate
+                violations.append(
+                    f"Suspicious sidepath in {resolved_root}: {rel_path}"
+                )
+
     return violations
 
 
@@ -156,7 +392,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--session", metavar="PREFIX",
                         help="Filter by session_id prefix")
     parser.add_argument("--check-only", action="store_true",
-                        help="Only perform leak/schema check, no display output")
+                        help="Only perform DB audit, no display output")
     args = parser.parse_args(argv)
 
     db_path = Path(args.db)
@@ -173,8 +409,7 @@ def main(argv: list[str] | None = None) -> int:
     violations: list[str] = []
 
     # Schema checks
-    violations += check_schema(conn)
-    violations += check_sidepath_columns(conn)
+    violations += collect_db_audit_violations(conn)
 
     if violations:
         for v in violations:
@@ -183,7 +418,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     if args.check_only:
-        logger.info("Schema check PASSED — no forbidden or unexpected columns.")
+        logger.info("DB audit PASSED — no schema or row-value violations.")
         conn.close()
         return 0
 
@@ -193,7 +428,7 @@ def main(argv: list[str] | None = None) -> int:
         print_session_detail(conn, args.session)
 
     conn.close()
-    logger.info("Inspection complete. No schema violations detected.")
+    logger.info("Inspection complete. No DB audit violations detected.")
     return 0
 
 

--- a/harness/runtime_server.py
+++ b/harness/runtime_server.py
@@ -1,0 +1,422 @@
+"""
+Minimal Runtime Server — Traumtänzer Harness Bootstrap
+
+Smallest deployable mono-process based on the existing harness components.
+
+Goals:
+  - explicit SQLite DB path (no fallback to harness/data/events.db)
+  - explicit log path (no fallback to workdir logs)
+  - simple reachability via HTTP /health
+  - clean shutdown with EventStore.close()
+  - fail-closed when no adapter/provider is configured
+  - content-free app logs (no user text, no LLM output, no raw payload)
+
+Non-goals:
+  - no production readiness claim
+  - no real provider integration
+  - no Hetzner evidence by itself
+  - no Docker / Compose / systemd
+
+Usage:
+  python -m harness.runtime_server --db /abs/path/events.db --log /abs/path/runtime.log
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import logging
+import signal
+import sys
+import threading
+import uuid
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from .event_store import EventStore
+from .kernel import Kernel
+from .llm_adapter import StubLLMAdapter, StubMode
+
+logger = logging.getLogger(__name__)
+
+_MAX_JSON_BYTES = 8 * 1024
+
+
+def _absolute_path_arg(value: str) -> Path:
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        raise argparse.ArgumentTypeError("Path must be absolute.")
+    return path
+
+
+def _port_arg(value: str) -> int:
+    try:
+        port = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("Port must be an integer.") from exc
+    if port < 1 or port > 65535:
+        raise argparse.ArgumentTypeError("Port must be between 1 and 65535.")
+    return port
+
+
+def _configure_logging(log_path: Path) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+        handler.close()
+
+    formatter = logging.Formatter(
+        fmt="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+
+    file_handler = logging.FileHandler(log_path, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(formatter)
+
+    root.setLevel(logging.INFO)
+    root.addHandler(file_handler)
+    root.addHandler(stderr_handler)
+
+
+@dataclass(frozen=True)
+class RuntimeConfig:
+    db_path: Path
+    log_path: Path
+    host: str
+    port: int
+    stub_mode: StubMode | None
+
+
+class RequestError(Exception):
+    def __init__(self, status: HTTPStatus, code: str) -> None:
+        super().__init__(code)
+        self.status = status
+        self.code = code
+
+
+class RuntimeApp:
+    """
+    Session registry around the existing Harness Kernel.
+
+    Keeps session state RAM-only. Runtime events remain content-free because the
+    underlying EventStore rejects free-text fields and the Kernel never logs
+    user content.
+    """
+
+    def __init__(self, config: RuntimeConfig) -> None:
+        self._config = config
+        self._store = EventStore(config.db_path)
+        self._sessions: dict[str, Kernel] = {}
+        logger.info(
+            "runtime_app_init bind=%s:%s adapter=%s",
+            config.host,
+            config.port,
+            self.adapter_mode,
+        )
+
+    @property
+    def adapter_mode(self) -> str:
+        return self._config.stub_mode.value if self._config.stub_mode else "NONE"
+
+    def health(self) -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "adapter_mode": self.adapter_mode,
+            "session_count": len(self._sessions),
+        }
+
+    def start_session(self) -> dict[str, Any]:
+        session_id = f"runtime-{uuid.uuid4().hex[:12]}"
+        kernel = Kernel(
+            session_id=session_id,
+            event_store=self._store,
+            llm_adapter=self._build_adapter(),
+        )
+        self._sessions[session_id] = kernel
+        logger.info("runtime_session_started session=%s", session_id[:8])
+        return {
+            "session_id": session_id,
+            "state": kernel.state,
+            "terminal": kernel.is_terminal(),
+            "response": kernel.entry_text(),
+        }
+
+    def process_turn(self, session_id: str, user_text: str) -> dict[str, Any]:
+        kernel = self._sessions.get(session_id)
+        if kernel is None:
+            raise RequestError(HTTPStatus.NOT_FOUND, "SESSION_NOT_FOUND")
+
+        response = kernel.process_input(user_text)
+        logger.info(
+            "runtime_turn_processed session=%s state=%s terminal=%s",
+            session_id[:8],
+            kernel.state,
+            kernel.is_terminal(),
+        )
+        return {
+            "session_id": session_id,
+            "state": kernel.state,
+            "terminal": kernel.is_terminal(),
+            "response": response,
+        }
+
+    def close(self) -> None:
+        self._store.close()
+        logger.info("runtime_app_closed sessions=%s", len(self._sessions))
+
+    def _build_adapter(self) -> StubLLMAdapter | None:
+        if self._config.stub_mode is None:
+            return None
+        return StubLLMAdapter(self._config.stub_mode)
+
+
+class RuntimeHTTPServer(HTTPServer):
+    allow_reuse_address = True
+
+    def __init__(self, server_address: tuple[str, int], app: RuntimeApp) -> None:
+        self.app = app
+        super().__init__(server_address, RuntimeRequestHandler)
+
+    def close_runtime(self) -> None:
+        try:
+            self.server_close()
+        finally:
+            self.app.close()
+
+
+class RuntimeRequestHandler(BaseHTTPRequestHandler):
+    server_version = "TraumtaenzerRuntime/0.1"
+    sys_version = ""
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = urlparse(self.path).path
+        if path == "/health":
+            self._send_json(HTTPStatus.OK, self.server.app.health())
+            return
+        self._send_json(HTTPStatus.NOT_FOUND, {"error": "NOT_FOUND"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        path = urlparse(self.path).path
+        try:
+            if path == "/shutdown":
+                payload = self._read_json_body(allow_empty=True)
+                if payload:
+                    raise RequestError(HTTPStatus.BAD_REQUEST, "UNEXPECTED_FIELDS")
+                if not self._client_is_loopback():
+                    raise RequestError(HTTPStatus.FORBIDDEN, "LOCALHOST_ONLY")
+                logger.info("runtime_shutdown_requested client=%s", self.client_address[0])
+                self._send_json(HTTPStatus.ACCEPTED, {"status": "shutdown_requested"})
+                threading.Thread(target=self.server.shutdown, daemon=True).start()
+                return
+
+            if path == "/v1/sessions":
+                payload = self._read_json_body(allow_empty=True)
+                if payload:
+                    raise RequestError(HTTPStatus.BAD_REQUEST, "UNEXPECTED_FIELDS")
+                self._send_json(HTTPStatus.CREATED, self.server.app.start_session())
+                return
+
+            if path == "/v1/turns":
+                payload = self._read_json_body()
+                session_id = payload.get("session_id")
+                user_text = payload.get("user_text")
+                if not isinstance(session_id, str) or not session_id.strip():
+                    raise RequestError(HTTPStatus.BAD_REQUEST, "INVALID_SESSION_ID")
+                if not isinstance(user_text, str):
+                    raise RequestError(HTTPStatus.BAD_REQUEST, "INVALID_USER_TEXT")
+                self._send_json(
+                    HTTPStatus.OK,
+                    self.server.app.process_turn(session_id, user_text),
+                )
+                return
+
+            self._send_json(HTTPStatus.NOT_FOUND, {"error": "NOT_FOUND"})
+        except RequestError as exc:
+            self._send_json(exc.status, {"error": exc.code})
+        except Exception as exc:
+            logger.error("runtime_request_failed err=%s", type(exc).__name__)
+            self._send_json(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                {"error": "INTERNAL_RUNTIME_ERROR"},
+            )
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        # Suppress BaseHTTPRequestHandler request logging to avoid accidentally
+        # logging raw request lines or user payloads.
+        return
+
+    def _client_is_loopback(self) -> bool:
+        try:
+            return ipaddress.ip_address(self.client_address[0]).is_loopback
+        except ValueError:
+            return self.client_address[0] in {"localhost"}
+
+    def _read_json_body(self, allow_empty: bool = False) -> dict[str, Any]:
+        raw_len = self.headers.get("Content-Length")
+        if raw_len is None:
+            if allow_empty:
+                return {}
+            raise RequestError(HTTPStatus.BAD_REQUEST, "MISSING_CONTENT_LENGTH")
+
+        try:
+            content_length = int(raw_len)
+        except ValueError as exc:
+            raise RequestError(HTTPStatus.BAD_REQUEST, "INVALID_CONTENT_LENGTH") from exc
+
+        if content_length < 0:
+            raise RequestError(HTTPStatus.BAD_REQUEST, "INVALID_CONTENT_LENGTH")
+        if content_length == 0:
+            if allow_empty:
+                return {}
+            raise RequestError(HTTPStatus.BAD_REQUEST, "EMPTY_BODY")
+        if content_length > _MAX_JSON_BYTES:
+            raise RequestError(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "PAYLOAD_TOO_LARGE")
+
+        raw = self.rfile.read(content_length)
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RequestError(HTTPStatus.BAD_REQUEST, "INVALID_JSON") from exc
+
+        if not isinstance(data, dict):
+            raise RequestError(HTTPStatus.BAD_REQUEST, "INVALID_JSON_OBJECT")
+        return data
+
+    def _send_json(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
+        response_body = json.dumps(payload, ensure_ascii=True).encode("utf-8")
+        self.send_response(int(status))
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(response_body)))
+        self.end_headers()
+        self.wfile.write(response_body)
+
+
+def create_runtime_server(config: RuntimeConfig) -> RuntimeHTTPServer:
+    app = RuntimeApp(config)
+    try:
+        return RuntimeHTTPServer((config.host, config.port), app)
+    except Exception:
+        app.close()
+        raise
+
+
+def _install_signal_handlers(server: RuntimeHTTPServer) -> None:
+    def _request_shutdown(signum: int, _frame: Any) -> None:
+        try:
+            signal_name = signal.Signals(signum).name
+        except ValueError:
+            signal_name = str(signum)
+        logger.info("runtime_shutdown_signal signal=%s", signal_name)
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    for sig_name in ("SIGINT", "SIGTERM"):
+        sig = getattr(signal, sig_name, None)
+        if sig is not None:
+            signal.signal(sig, _request_shutdown)
+
+
+def _stub_mode_arg(value: str) -> StubMode | None:
+    if value.upper() == "NONE":
+        return None
+    try:
+        return StubMode(value.upper())
+    except ValueError as exc:
+        allowed = ", ".join(["NONE", *[mode.value for mode in StubMode]])
+        raise argparse.ArgumentTypeError(
+            f"Invalid stub mode. Allowed: {allowed}"
+        ) from exc
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Traumtänzer Harness Bootstrap Runtime Server"
+    )
+    parser.add_argument(
+        "--db",
+        required=True,
+        type=_absolute_path_arg,
+        help="Absolute SQLite DB path. Required; no default fallback.",
+    )
+    parser.add_argument(
+        "--log",
+        required=True,
+        type=_absolute_path_arg,
+        help="Absolute log file path. Required; no default fallback.",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Bind host (default: 127.0.0.1).",
+    )
+    parser.add_argument(
+        "--port",
+        type=_port_arg,
+        default=8080,
+        help="Bind port (default: 8080).",
+    )
+    parser.add_argument(
+        "--stub-mode",
+        default="NONE",
+        type=_stub_mode_arg,
+        metavar="MODE",
+        help="Optional StubLLMAdapter mode. Default: NONE (missing provider -> fail-closed).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    if args.db == args.log:
+        parser.error("--db and --log must point to different files.")
+
+    config = RuntimeConfig(
+        db_path=args.db,
+        log_path=args.log,
+        host=args.host,
+        port=args.port,
+        stub_mode=args.stub_mode,
+    )
+
+    _configure_logging(config.log_path)
+    logger.info(
+        "runtime_bootstrap_start bind=%s:%s adapter=%s db_path=%s log_path=%s",
+        config.host,
+        config.port,
+        "NONE" if config.stub_mode is None else config.stub_mode.value,
+        config.db_path,
+        config.log_path,
+    )
+
+    server: RuntimeHTTPServer | None = None
+    try:
+        server = create_runtime_server(config)
+        _install_signal_handlers(server)
+        logger.info("runtime_server_ready bind=%s:%s", config.host, config.port)
+        server.serve_forever(poll_interval=0.5)
+        return 0
+    except KeyboardInterrupt:
+        logger.info("runtime_keyboard_interrupt")
+        return 0
+    except Exception as exc:
+        logger.error("runtime_bootstrap_failed err=%s", type(exc).__name__)
+        return 1
+    finally:
+        if server is not None:
+            server.close_runtime()
+        logger.info("runtime_bootstrap_stopped")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/harness/runtime_tools.py
+++ b/harness/runtime_tools.py
@@ -1,0 +1,462 @@
+"""
+Runtime Tooling — start / stop / health / inspect
+
+Minimal operational paths for the bootstrap runtime server.
+
+Commands:
+  start       Launch runtime_server in background and verify /health
+  stop        Request clean shutdown and verify process exit
+  health      Check /health reachability
+  inspect-db  Inspect explicit SQLite DB path
+  inspect-log Inspect explicit runtime log path
+  inspect-sidepaths Scan explicit roots for shadow stores / sidepaths
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import signal
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from .event_store import _FORBIDDEN_FIELDS
+from .inspect_events import (
+    collect_db_audit_violations,
+    print_session_detail,
+    print_summary,
+    scan_sidepaths,
+)
+from .llm_adapter import _STUB_RESPONSES
+from .responses import RESPONSES
+from .runtime_server import _absolute_path_arg, _port_arg, _stub_mode_arg
+
+logger = logging.getLogger(__name__)
+
+_MAX_LOG_LINES = 200
+
+
+def _configure_cli_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def _read_pid_meta(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"PID file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Invalid PID file: {path}") from exc
+
+    if not isinstance(data, dict):
+        raise RuntimeError(f"Invalid PID file structure: {path}")
+    return data
+
+
+def _write_pid_meta(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _request_json(method: str, url: str, payload: dict[str, Any] | None = None, timeout: float = 3.0) -> tuple[int, dict[str, Any]]:
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    headers = {}
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+    request = Request(url, data=body, method=method, headers=headers)
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            status = response.status
+            raw = response.read().decode("utf-8")
+    except HTTPError as exc:
+        raw = exc.read().decode("utf-8")
+        try:
+            return exc.code, json.loads(raw)
+        except json.JSONDecodeError:
+            return exc.code, {"error": "NON_JSON_ERROR_RESPONSE"}
+    except (URLError, OSError) as exc:
+        raise RuntimeError(type(exc).__name__) from exc
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Invalid JSON response") from exc
+    if not isinstance(data, dict):
+        raise RuntimeError("Invalid JSON object response")
+    return status, data
+
+
+def _health_url(host: str, port: int) -> str:
+    return f"http://{host}:{port}/health"
+
+
+def _shutdown_url(host: str, port: int) -> str:
+    return f"http://{host}:{port}/shutdown"
+
+
+def _runtime_command(args: argparse.Namespace) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "harness.runtime_server",
+        "--db",
+        str(args.db),
+        "--log",
+        str(args.log),
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+        "--stub-mode",
+        "NONE" if args.stub_mode is None else args.stub_mode.value,
+    ]
+
+
+def _health_available(host: str, port: int, timeout: float = 1.0) -> bool:
+    try:
+        status, _payload = _request_json("GET", _health_url(host, port), timeout=timeout)
+    except RuntimeError:
+        return False
+    return status == 200
+
+
+def _wait_for_health(host: str, port: int, timeout_seconds: float, process: subprocess.Popen[Any]) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    last_error = "HEALTH_TIMEOUT"
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError("RUNTIME_PROCESS_EXITED_DURING_STARTUP")
+        try:
+            status, data = _request_json("GET", _health_url(host, port), timeout=1.0)
+            if status == 200:
+                return data
+            last_error = data.get("error", f"HTTP_{status}")
+        except RuntimeError as exc:
+            last_error = str(exc)
+        time.sleep(0.2)
+    raise RuntimeError(last_error)
+
+
+def _wait_for_exit(pid: int, timeout_seconds: float) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if not _pid_alive(pid):
+            return True
+        time.sleep(0.2)
+    return not _pid_alive(pid)
+
+
+def _cleanup_wal_shm(db_path: Path) -> list[str]:
+    violations: list[str] = []
+    wal_path = Path(str(db_path) + "-wal")
+    shm_path = Path(str(db_path) + "-shm")
+    if wal_path.exists():
+        violations.append(str(wal_path))
+    if shm_path.exists():
+        violations.append(str(shm_path))
+    return violations
+
+
+def _stop_signal() -> int:
+    return signal.SIGTERM
+
+
+def _extract_forbidden_log_patterns() -> list[str]:
+    patterns = set(_FORBIDDEN_FIELDS)
+    patterns.update({"raw_payload", "request_body", "response_body", "user_text=", "llm_output="})
+    patterns.update(RESPONSES.values())
+    patterns.update(_STUB_RESPONSES.values())
+    return sorted(patterns)
+
+
+def cmd_start(args: argparse.Namespace) -> int:
+    if len({args.db, args.log, args.pid_file}) != 3:
+        raise RuntimeError("--db, --log and --pid-file must be different paths.")
+
+    if args.pid_file.exists():
+        meta = _read_pid_meta(args.pid_file)
+        existing_host = str(meta.get("host", args.host))
+        existing_port = int(meta.get("port", args.port))
+        if existing_port and _health_available(existing_host, existing_port):
+            raise RuntimeError(f"Runtime already running under PID file: {args.pid_file}")
+        args.pid_file.unlink()
+
+    kwargs: dict[str, Any] = {
+        "cwd": str(_repo_root()),
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+    }
+    if os.name == "nt":
+        kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+    else:
+        kwargs["start_new_session"] = True
+
+    process = subprocess.Popen(_runtime_command(args), **kwargs)
+
+    try:
+        health = _wait_for_health(args.host, args.port, args.startup_timeout, process)
+    except Exception:
+        if process.poll() is None:
+            try:
+                os.kill(process.pid, _stop_signal())
+            except OSError:
+                pass
+        raise
+
+    meta = {
+        "pid": process.pid,
+        "host": args.host,
+        "port": args.port,
+        "db_path": str(args.db),
+        "log_path": str(args.log),
+        "stub_mode": "NONE" if args.stub_mode is None else args.stub_mode.value,
+    }
+    _write_pid_meta(args.pid_file, meta)
+    print(json.dumps({"status": "started", **meta, "health": health}, ensure_ascii=True))
+    return 0
+
+
+def cmd_stop(args: argparse.Namespace) -> int:
+    meta = _read_pid_meta(args.pid_file)
+    pid = int(meta.get("pid", 0))
+    host = str(meta.get("host", "127.0.0.1"))
+    port = int(meta.get("port", 0))
+    db_path = _absolute_path_arg(str(meta.get("db_path", "")))
+
+    if not pid:
+        raise RuntimeError(f"PID file has no pid: {args.pid_file}")
+
+    if not _health_available(host, port):
+        if args.pid_file.exists():
+            args.pid_file.unlink()
+        print(json.dumps({"status": "already_stopped", "pid": pid}, ensure_ascii=True))
+        return 0
+
+    shutdown_requested = False
+    if port:
+        try:
+            status, _data = _request_json("POST", _shutdown_url(host, port), payload={}, timeout=2.0)
+            shutdown_requested = status == 202
+        except RuntimeError:
+            shutdown_requested = False
+
+    if not shutdown_requested:
+        os.kill(pid, _stop_signal())
+
+    deadline = time.monotonic() + args.stop_timeout
+    while time.monotonic() < deadline:
+        if not _health_available(host, port, timeout=0.5):
+            break
+        time.sleep(0.2)
+    else:
+        raise RuntimeError("Runtime did not stop cleanly within timeout.")
+
+    if args.pid_file.exists():
+        args.pid_file.unlink()
+
+    wal_violations = _cleanup_wal_shm(db_path)
+    if wal_violations:
+        raise RuntimeError(f"WAL/SHM files remain after clean stop: {wal_violations}")
+
+    print(json.dumps({"status": "stopped", "pid": pid, "db_path": str(db_path)}, ensure_ascii=True))
+    return 0
+
+
+def cmd_health(args: argparse.Namespace) -> int:
+    status, payload = _request_json("GET", _health_url(args.host, args.port), timeout=args.timeout)
+    if status != 200:
+        raise RuntimeError(payload.get("error", f"HTTP_{status}"))
+    print(json.dumps(payload, ensure_ascii=True))
+    return 0
+
+
+def cmd_inspect_db(args: argparse.Namespace) -> int:
+    if not args.db.exists():
+        raise RuntimeError(f"DB not found: {args.db}")
+
+    conn = sqlite3.connect(str(args.db), check_same_thread=False)
+    try:
+        violations = collect_db_audit_violations(conn)
+        if violations:
+            for violation in violations:
+                logger.error("DB_INSPECT_VIOLATION %s", violation)
+            return 1
+
+        if args.check_only:
+            print(json.dumps({"status": "ok", "db_path": str(args.db)}, ensure_ascii=True))
+            return 0
+
+        print_summary(conn, session_prefix=args.session)
+        if args.session:
+            print_session_detail(conn, args.session)
+        return 0
+    finally:
+        conn.close()
+
+
+def _tail_lines(path: Path, count: int) -> list[str]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if count <= 0:
+        return lines
+    return lines[-count:]
+
+
+def _stdout_safe(text: str) -> str:
+    encoding = sys.stdout.encoding or "utf-8"
+    return text.encode(encoding, errors="replace").decode(encoding, errors="replace")
+
+
+def cmd_inspect_log(args: argparse.Namespace) -> int:
+    if not args.log.exists():
+        raise RuntimeError(f"Log not found: {args.log}")
+
+    tail_count = min(args.tail, _MAX_LOG_LINES)
+    lines = _tail_lines(args.log, tail_count)
+    text = "\n".join(lines)
+
+    violations: list[str] = []
+    for pattern in _extract_forbidden_log_patterns():
+        if pattern and pattern in text:
+            violations.append(pattern)
+
+    if violations:
+        for pattern in violations:
+            logger.error("LOG_INSPECT_VIOLATION forbidden_pattern=%r", pattern)
+        return 1
+
+    if args.check_only:
+        print(json.dumps({"status": "ok", "log_path": str(args.log), "tail_lines": len(lines)}, ensure_ascii=True))
+        return 0
+
+    print(f"Log tail from {args.log} ({len(lines)} lines):")
+    for line in lines:
+        print(_stdout_safe(line))
+    return 0
+
+
+def cmd_inspect_sidepaths(args: argparse.Namespace) -> int:
+    scan_roots = [args.db.parent, args.workdir]
+    if args.log is not None:
+        scan_roots.append(args.log.parent)
+
+    allowed_paths = {args.db}
+    if args.log is not None:
+        allowed_paths.add(args.log)
+    if args.pid_file is not None:
+        allowed_paths.add(args.pid_file)
+
+    resolved_roots: list[Path] = []
+    seen_roots: set[Path] = set()
+    for path in scan_roots:
+        resolved = path.resolve(strict=False)
+        if resolved in seen_roots:
+            continue
+        seen_roots.add(resolved)
+        resolved_roots.append(path)
+
+    violations = scan_sidepaths(resolved_roots, allowed_paths=allowed_paths)
+    if violations:
+        for violation in violations:
+            logger.error("SIDEPATH_VIOLATION %s", violation)
+        return 1
+
+    payload = {
+        "status": "ok",
+        "scan_roots": [str(path.resolve(strict=False)) for path in resolved_roots],
+        "allowed_paths": [
+            str(path.resolve(strict=False))
+            for path in sorted(allowed_paths, key=lambda item: str(item.resolve(strict=False)))
+        ],
+    }
+    print(json.dumps(payload, ensure_ascii=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Traumtänzer Runtime Tooling")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    start = subparsers.add_parser("start", help="Start runtime server in background")
+    start.add_argument("--db", required=True, type=_absolute_path_arg, help="Absolute SQLite DB path.")
+    start.add_argument("--log", required=True, type=_absolute_path_arg, help="Absolute runtime log path.")
+    start.add_argument("--pid-file", required=True, type=_absolute_path_arg, help="Absolute PID metadata path.")
+    start.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1).")
+    start.add_argument("--port", type=_port_arg, default=8080, help="Bind port (default: 8080).")
+    start.add_argument("--stub-mode", default="NONE", type=_stub_mode_arg, metavar="MODE")
+    start.add_argument("--startup-timeout", type=float, default=10.0, help="Seconds to wait for /health (default: 10).")
+    start.set_defaults(func=cmd_start)
+
+    stop = subparsers.add_parser("stop", help="Stop runtime server via local shutdown path")
+    stop.add_argument("--pid-file", required=True, type=_absolute_path_arg, help="Absolute PID metadata path.")
+    stop.add_argument("--stop-timeout", type=float, default=10.0, help="Seconds to wait for clean exit (default: 10).")
+    stop.set_defaults(func=cmd_stop)
+
+    health = subparsers.add_parser("health", help="Check runtime /health")
+    health.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1).")
+    health.add_argument("--port", type=_port_arg, default=8080, help="Bind port (default: 8080).")
+    health.add_argument("--timeout", type=float, default=3.0, help="Request timeout seconds (default: 3).")
+    health.set_defaults(func=cmd_health)
+
+    inspect_db = subparsers.add_parser("inspect-db", help="Inspect explicit SQLite DB path")
+    inspect_db.add_argument("--db", required=True, type=_absolute_path_arg, help="Absolute SQLite DB path.")
+    inspect_db.add_argument("--session", metavar="PREFIX", help="Optional session prefix filter.")
+    inspect_db.add_argument("--check-only", action="store_true", help="Only run DB audit, no display output.")
+    inspect_db.set_defaults(func=cmd_inspect_db)
+
+    inspect_log = subparsers.add_parser("inspect-log", help="Inspect explicit runtime log path")
+    inspect_log.add_argument("--log", required=True, type=_absolute_path_arg, help="Absolute runtime log path.")
+    inspect_log.add_argument("--tail", type=int, default=40, help="How many trailing lines to inspect (max 200).")
+    inspect_log.add_argument("--check-only", action="store_true", help="Only validate, no line output.")
+    inspect_log.set_defaults(func=cmd_inspect_log)
+
+    inspect_sidepaths = subparsers.add_parser(
+        "inspect-sidepaths",
+        help="Scan target directory and workdir for shadow stores / sidepaths",
+    )
+    inspect_sidepaths.add_argument("--db", required=True, type=_absolute_path_arg, help="Absolute SQLite DB path.")
+    inspect_sidepaths.add_argument("--workdir", required=True, type=_absolute_path_arg, help="Absolute workdir root to scan.")
+    inspect_sidepaths.add_argument("--log", type=_absolute_path_arg, help="Optional absolute runtime log path to allow.")
+    inspect_sidepaths.add_argument("--pid-file", type=_absolute_path_arg, help="Optional absolute pid metadata path to allow.")
+    inspect_sidepaths.set_defaults(func=cmd_inspect_sidepaths)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    _configure_cli_logging()
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except RuntimeError as exc:
+        logger.error("%s", exc)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Kontext
Reslice von PR #62 fuer den Runtime-/Inspect-P0-Block von Issue #60.

Refs #60

## Enthaltener Commit
- `a93a25a8d51747d01051f08776d99def0f255c37`

## Was enthalten ist
- minimaler Runtime-Entrypoint auf Basis von `harness/`
- reproduzierbare Tooling-Pfade fuer `start`, `stop`, `health`, `inspect-db`, `inspect-log`
- Row-Value-Redaction-Audit fuer SQLite-Events
- expliziter Sidepath-/Shadow-Store-Scan
- kanonische Enum-Persistenz im Event-Store
- Stop-Pfad mit sauberem Shutdown-Randfall-Handling

## Basis
Dieser PR basiert bewusst auf `issue-60-harness-foundation`, nicht direkt auf `main`, weil der Runtime-/Inspect-Block die Harness-Grundsubstanz voraussetzt.

## Was bewusst offen bleibt
- kein echter Hetzner-/Volume-Nachweis
- keine TTL-/VACUUM-Logik
- keine Behauptung realer Hetzner-Evidence
