### PR TITLE
feat(harness): add explicit workdir path contract

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -97,6 +97,7 @@ python -m harness.runtime_tools start \
   --db /absolute/path/events.db \
   --log /absolute/path/runtime.log \
   --pid-file /absolute/path/runtime.pid \
+  --workdir /absolute/path/workdir \
   --host 127.0.0.1 \
   --port 8080
 
@@ -122,8 +123,10 @@ python -m harness.runtime_tools stop --pid-file /absolute/path/runtime.pid
 
 Grenzen:
 - auch dieses Tooling ist kein Hetzner-Nachweis
+- `start` verlangt ein explizites absolutes `--workdir`; kein Fallback auf Repo-Root oder zufälligen Startkontext
+- `app_root` bleibt der Repo-Checkout mit `harness/`; `start` schreibt `app_root` und `workdir` in die PID-Metadaten
 - `inspect-db` und `inspect-log` akzeptieren nur explizite absolute Pfade
-- `inspect-sidepaths` scannt nur die explizit benannten Roots; keine impliziten Fallback-Pfade
+- `inspect-sidepaths` scannt nur die explizit benannten Roots; dieselbe `workdir`-Bindung muss aus `start` übernommen werden; keine impliziten Fallback-Pfade
 - das Stop-Tooling nutzt nur lokale Kontrollpfade; keine Remote-Orchestrierung
 
 ---

--- a/harness/inspect_events.py
+++ b/harness/inspect_events.py
@@ -332,7 +332,7 @@ def print_summary(conn: sqlite3.Connection, session_prefix: str | None = None) -
             "SELECT event_type, timestamp FROM events WHERE session_id = ? ORDER BY id DESC LIMIT 1",
             (sid,),
         ).fetchone()
-        last_type, last_ts = last if last else ("—", "—")
+        last_type, last_ts = last if last else ("-", "-")
         print(f"  {sid[:20]:<22} {count:>4} events  last={last_type} @ {last_ts[:19]}")
 
     if len(sessions) > 20:
@@ -367,7 +367,7 @@ def print_session_detail(conn: sqlite3.Connection, session_prefix: str) -> None:
         if vtype:
             details.append(f"violation={vtype}")
         if frm or to:
-            details.append(f"{frm}→{to}")
+            details.append(f"{frm}->{to}")
         if trigger:
             details.append(f"trigger={trigger}")
         if end_type:

--- a/harness/runtime_tools.py
+++ b/harness/runtime_tools.py
@@ -4,7 +4,7 @@ Runtime Tooling — start / stop / health / inspect
 Minimal operational paths for the bootstrap runtime server.
 
 Commands:
-  start       Launch runtime_server in background and verify /health
+  start       Launch runtime_server in background with explicit workdir and verify /health
   stop        Request clean shutdown and verify process exit
   health      Check /health reachability
   inspect-db  Inspect explicit SQLite DB path
@@ -54,6 +54,24 @@ def _configure_cli_logging() -> None:
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
+
+
+def _absolute_existing_dir_arg(value: str) -> Path:
+    path = _absolute_path_arg(value)
+    if not path.exists():
+        raise argparse.ArgumentTypeError("Directory must exist.")
+    if not path.is_dir():
+        raise argparse.ArgumentTypeError("Path must point to a directory.")
+    return path
+
+
+def _runtime_env(app_root: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        str(app_root) if not existing else f"{app_root}{os.pathsep}{existing}"
+    )
+    return env
 
 
 def _pid_alive(pid: int) -> bool:
@@ -197,6 +215,9 @@ def cmd_start(args: argparse.Namespace) -> int:
     if len({args.db, args.log, args.pid_file}) != 3:
         raise RuntimeError("--db, --log and --pid-file must be different paths.")
 
+    app_root = _repo_root().resolve(strict=False)
+    workdir = args.workdir.resolve(strict=False)
+
     if args.pid_file.exists():
         meta = _read_pid_meta(args.pid_file)
         existing_host = str(meta.get("host", args.host))
@@ -206,7 +227,8 @@ def cmd_start(args: argparse.Namespace) -> int:
         args.pid_file.unlink()
 
     kwargs: dict[str, Any] = {
-        "cwd": str(_repo_root()),
+        "cwd": str(workdir),
+        "env": _runtime_env(app_root),
         "stdin": subprocess.DEVNULL,
         "stdout": subprocess.DEVNULL,
         "stderr": subprocess.DEVNULL,
@@ -234,6 +256,8 @@ def cmd_start(args: argparse.Namespace) -> int:
         "port": args.port,
         "db_path": str(args.db),
         "log_path": str(args.log),
+        "app_root": str(app_root),
+        "workdir": str(workdir),
         "stub_mode": "NONE" if args.stub_mode is None else args.stub_mode.value,
     }
     _write_pid_meta(args.pid_file, meta)
@@ -246,6 +270,8 @@ def cmd_stop(args: argparse.Namespace) -> int:
     pid = int(meta.get("pid", 0))
     host = str(meta.get("host", "127.0.0.1"))
     port = int(meta.get("port", 0))
+    app_root = meta.get("app_root")
+    workdir = meta.get("workdir")
     db_path = _absolute_path_arg(str(meta.get("db_path", "")))
 
     if not pid:
@@ -254,7 +280,12 @@ def cmd_stop(args: argparse.Namespace) -> int:
     if not _health_available(host, port):
         if args.pid_file.exists():
             args.pid_file.unlink()
-        print(json.dumps({"status": "already_stopped", "pid": pid}, ensure_ascii=True))
+        payload: dict[str, Any] = {"status": "already_stopped", "pid": pid}
+        if isinstance(app_root, str):
+            payload["app_root"] = app_root
+        if isinstance(workdir, str):
+            payload["workdir"] = workdir
+        print(json.dumps(payload, ensure_ascii=True))
         return 0
 
     shutdown_requested = False
@@ -283,7 +314,12 @@ def cmd_stop(args: argparse.Namespace) -> int:
     if wal_violations:
         raise RuntimeError(f"WAL/SHM files remain after clean stop: {wal_violations}")
 
-    print(json.dumps({"status": "stopped", "pid": pid, "db_path": str(db_path)}, ensure_ascii=True))
+    payload = {"status": "stopped", "pid": pid, "db_path": str(db_path)}
+    if isinstance(app_root, str):
+        payload["app_root"] = app_root
+    if isinstance(workdir, str):
+        payload["workdir"] = workdir
+    print(json.dumps(payload, ensure_ascii=True))
     return 0
 
 
@@ -401,10 +437,19 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Traumtänzer Runtime Tooling")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    start = subparsers.add_parser("start", help="Start runtime server in background")
+    start = subparsers.add_parser(
+        "start",
+        help="Start runtime server in background with explicit workdir",
+    )
     start.add_argument("--db", required=True, type=_absolute_path_arg, help="Absolute SQLite DB path.")
     start.add_argument("--log", required=True, type=_absolute_path_arg, help="Absolute runtime log path.")
     start.add_argument("--pid-file", required=True, type=_absolute_path_arg, help="Absolute PID metadata path.")
+    start.add_argument(
+        "--workdir",
+        required=True,
+        type=_absolute_existing_dir_arg,
+        help="Absolute existing workdir for the launched runtime; required and used as process cwd.",
+    )
     start.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1).")
     start.add_argument("--port", type=_port_arg, default=8080, help="Bind port (default: 8080).")
     start.add_argument("--stub-mode", default="NONE", type=_stub_mode_arg, metavar="MODE")
@@ -439,7 +484,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Scan target directory and workdir for shadow stores / sidepaths",
     )
     inspect_sidepaths.add_argument("--db", required=True, type=_absolute_path_arg, help="Absolute SQLite DB path.")
-    inspect_sidepaths.add_argument("--workdir", required=True, type=_absolute_path_arg, help="Absolute workdir root to scan.")
+    inspect_sidepaths.add_argument(
+        "--workdir",
+        required=True,
+        type=_absolute_existing_dir_arg,
+        help="Absolute workdir root to scan; must match the explicit workdir used for start.",
+    )
     inspect_sidepaths.add_argument("--log", type=_absolute_path_arg, help="Optional absolute runtime log path to allow.")
     inspect_sidepaths.add_argument("--pid-file", type=_absolute_path_arg, help="Optional absolute pid metadata path to allow.")
     inspect_sidepaths.set_defaults(func=cmd_inspect_sidepaths)

--- a/knowledge/ACTIVE_ROADMAP.md
+++ b/knowledge/ACTIVE_ROADMAP.md
@@ -1,6 +1,6 @@
 # ACTIVE_ROADMAP
 
-Stand: 2026-03-27 – synchronisiert mit `main` (nach gemergter Docs-/Spec-Kette bis PR #42)
+Stand: 2026-03-30 – synchronisiert mit `main` (nach gemergtem PR-Stack #63–#65)
 
 ---
 
@@ -21,21 +21,23 @@ Stand: 2026-03-27 – synchronisiert mit `main` (nach gemergter Docs-/Spec-Kette
 - Mono-Safety-Incident-Logik (PR #40): Incident-Stufen und Postmortem-Minimum in PILOT_READINESS.md
 - AI-Transparenz / Disclosure / Anti-Manipulation (PR #41): CLAIMS_FRAMEWORK.md, UX_CORE_SEQUENCE.md geschärft
 - Data-Lifecycle-Matrix (PR #42): DATA_LIFECYCLE.md
+- Bootstrap-Runtime-Grundpfad (PRs #63–#65): `harness/runtime_server.py`, `harness/runtime_tools.py`, `harness/inspect_events.py`, `harness/event_store.py`; `/health`, explizite absolute Pfade, fail-closed ohne Adapter, lokale DB-/Log-/Sidepath-Inspektion
 
 ---
 
 ## Now
 
 - **Kein freigabefähiger externer LLM-Pfad** (P0-Blocker vor Live-Nutzer): fünf Pfade bewertet (Azure OpenAI, Anthropic Claude API, Amazon Bedrock, OpenAI API, IONOS AI Model Hub) – keiner `zulässig für Pilot`; Provider-Gate bleibt offen
-- **Degraded mode ist kein Ersatzpilot**: degraded mode ist ausschließlich Safe-/Fehlerbetrieb; Live-Pilot nur mit freigegebenem externem LLM-Pfad
-- **Lokales Harness vorhanden** (`harness/`): Kernel-Zustandsmaschine, deterministische Guards, content-freier SQLite-Event-Store, Stub-Adapter, Fault-Injection, Smoke-Check und Szenarien-Runner implementiert; nicht-provider-gekoppelte Testfälle lokal ausführbar; Hetzner-deploybare Runtime fehlt weiterhin; Vorbedingungsliste für Hetzner-Pfad in `OPERATIONS_RUNBOOK §3`; provider-gekoppelte Pflichtfälle bleiben `blockiert`
+- **Degraded mode ist kein Ersatzpilot**: degraded mode ist ausschließlich Safe-/Fehlerbetrieb; Live-Pilot nur mit freigegebenem externem LLM-Pfad; kein Non-LLM-Ersatzpilot im aktuellen MVP-Scope
+- **Bootstrap-Runtime-Pfad vorhanden** (`harness/`): Kernel-Zustandsmaschine, deterministische Guards, content-freier SQLite-Event-Store, Stub-Adapter, Fault-Injection, Smoke-Check, Szenarien-Runner sowie `runtime_server.py` + `runtime_tools.py` auf `main`; Start / Stop / Health / Inspect lokal mit expliziten absoluten Pfaden und explizitem `workdir`-Scanroot belegbar; offen ist jetzt die Hetzner-Zielpfadbindung samt erster evidenzfähiger Rezeptur, nicht weiterer Runtime-Neubau; provider-gekoppelte Pflichtfälle bleiben `blockiert`
 
 ---
 
 ## Next
 
+- `Hetzner Bootstrap Path Contract + First Evidence Recipe`: `app_root`, `workdir`, `volume_mount`, `db_path`, `log_path`, `pid_file`, `bind_host`, `bind_port` für genau einen realen Zielpfad festziehen; repo-seitig ist die explizite `workdir`-Bindung vorbereitet; vorhandenen Bootstrap-Pfad in der Sequenz `start -> health -> kurzer Session-Smoke -> inspect-db -> inspect-log -> inspect-sidepaths -> stop` fahren; Abschluss nur mit den vier Artefaktklassen aus `OPERATIONS_RUNBOOK §4`
 - Export-/IAM-Pfad nur bei echtem Persistenzbedarf konkretisieren
-- Non-LLM-MVP nur falls separat entschieden: eigener Scope, kein Fallback des aktuellen Piloten und keine Voraussetzung für Pilotfreigabe im aktuellen Rahmen
+- Non-LLM-MVP aktuell nicht Teil des MVP-Scope; nur falls separat entschieden: eigener Scope, kein Fallback des aktuellen Piloten und keine Voraussetzung für Pilotfreigabe im aktuellen Rahmen
 
 ---
 

--- a/knowledge/CURRENT_STATUS.md
+++ b/knowledge/CURRENT_STATUS.md
@@ -1,23 +1,26 @@
 # CURRENT_STATUS – Traumtänzer
 
-Zuletzt aktualisiert: 2026-03-27
+Zuletzt aktualisiert: 2026-03-30
 
 ---
 
 ## Aktueller Stand
 
 **Branch:** `main`
-**PRs:** Docs-/Spec- und Sync-PRs bis #56 gemergt – Canon-Grundstock,
-Provider- und Infrastrukturentscheide auf `main`
+**PRs:** PR-Stack #63, #64 und #65 gemergt; #62 geschlossen/superseded –
+Bootstrap-Runtime-Pfad und Canon-Sync auf `main`
 **Phase:** Core-Canon, Providerprüfung (fünf externe LLM-Pfade bewertet:
 Azure OpenAI, Anthropic Claude API, Amazon Bedrock, OpenAI API, IONOS AI
 Model Hub – keiner freigabefähig), Pilot-Infrastrukturpfad und die auf die
 konkrete Zielumgebung gespiegelt definierte MVP-Evidence-Baseline stehen; die
 dokumentierte reale Durchführung der Pflichtfälle steht insgesamt aus –
-nicht-providergekoppelte Fälle mangels Runtime-/Deploy-/Runbook-Substanz
-als `Vorbedingung fehlt`, providergekoppelte Fälle durch das offene
-Provider-Gate `blockiert`; degraded mode ist kein Pilot-Scope, sondern
-nur Safe-/Fehlerbetrieb
+auf dem Hetzner-Pilotpfad bleiben nicht-providergekoppelte Fälle mangels
+kanonisch gebundenem Zielpfad und erstem evidenzfähigen Runbook-Rezept
+`Vorbedingung fehlt`, providergekoppelte Fälle durch das offene
+Provider-Gate `blockiert`; ein lokaler Bootstrap-Runtime-Pfad auf `main`
+ist vorhanden, aber noch nicht an einen echten Hetzner-Zielpfad gebunden;
+degraded mode ist kein Pilot-Scope, sondern nur Safe-/Fehlerbetrieb; ein
+Non-LLM-Ersatzpilot ist im aktuellen MVP-Scope nicht entschieden
 
 ---
 
@@ -51,6 +54,10 @@ nur Safe-/Fehlerbetrieb
 ### Ops (gemergt)
 - `knowledge/ops/PILOT_READINESS.md` – Go/No-Go-Kriterien, Stop-Kriterien und Incident-/Eskalationslogik für den Pilot
 
+### Harness / Bootstrap (PRs #63–#65)
+- `harness/runtime_server.py`, `harness/runtime_tools.py`, `harness/inspect_events.py`, `harness/event_store.py` – minimaler Bootstrap-Runtime-Pfad mit `/health`, expliziten absoluten Pfaden, fail-closed ohne Adapter und lokalen DB-/Log-/Sidepath-Inspektionen
+- `harness/README.md` – operatorische Ausführung und Grenzen des lokalen Bootstrap-/Harness-Pfads
+
 ### Foundation
 - `README.md` – projektspezifisch, kein generisches Repo-Pack mehr
 - `CODEOWNERS` – korrekt gesetzt (@jannekbuengener)
@@ -74,7 +81,7 @@ nur Safe-/Fehlerbetrieb
 |---|---|---|
 | Nach Bewertung von Azure OpenAI, Anthropic Claude API (`/v1/messages`), Amazon Bedrock (`InvokeModel` + `anthropic.claude-sonnet-4-6`), OpenAI API (`eu.api.openai.com`, `POST /v1/chat/completions`) und IONOS AI Model Hub (`POST /v1/chat/completions`) ist aktuell kein externer LLM-Pfad freigabefähig; produktnahe Subprocessor-, Löschpfad- und Side-Artifact-Blocker bleiben live-relevant | P0 vor Live-Nutzer | PROVIDER_DPA_INPUT_MATRIX §7–§8 |
 | Die minimale Red-Team-/Prompt-Testbaseline ist auf den freigegebenen Pilotpfad gespiegelt; dokumentierte Pflichtnachweise sind definiert; providergekoppelte Fälle sind `blockiert` (kein freigegebener LLM-Pfad); auf dem Hetzner-Pilotpfad verbleiben nicht-providergekoppelte Fälle auf `Vorbedingung fehlt`; im lokalen Harness sind bestimmte Fälle (Gruppen A/B) prüfbar (→ PROMPT_TEST_BASELINE §3.2); degraded mode ist kein Ersatzpilot | P0 vor Live-Nutzer | PROMPT_TEST_BASELINE §3.1–§3.2, PILOT_READINESS §3.3 |
-| Lokales Harness (`harness/`) vorhanden: Kernel, Guards, Stub-Adapter, content-freier SQLite-Event-Store, Fault-Injection, Smoke-Check und Szenarien-Runner; Fallgruppen-Mapping gegen Baseline in PROMPT_TEST_BASELINE §3.2 dokumentiert; Hetzner-deploybare Runtime fehlt weiterhin; lokale Harness-Artefakte sind kein Pilot-Nachweis; konkrete Hetzner-Vorbedingungen in OPERATIONS_RUNBOOK §3 | P0 vor Evidence-Ausführung (Hetzner-Pfad) | PROMPT_TEST_BASELINE §3.2, OPERATIONS_RUNBOOK §3–§9 |
+| Lokaler Bootstrap-Runtime-Pfad (`harness/runtime_server.py`, `harness/runtime_tools.py`) auf `main` vorhanden: Start / Stop / Health / kurzer Session-Smoke / DB-/Log-/Sidepath-Inspect lokal mit expliziten absoluten Pfaden und explizitem `workdir`-Scanroot möglich; offene Lücke ist jetzt `Hetzner Bootstrap Path Contract + First Evidence Recipe`, nicht weiterer Runtime-Neubau; lokale Harness-Artefakte bleiben kein Pilot-Nachweis | P0 vor Evidence-Ausführung (Hetzner-Pfad) | PROMPT_TEST_BASELINE §3.2, OPERATIONS_RUNBOOK §2.1, §3–§9 |
 | Externe Ressourcenliste über Deutschland hinaus erweitern | bei Produktisierung | SAFETY_PLAYBOOK §7 |
 
 ---
@@ -85,13 +92,22 @@ Zwei P0-Blocker bleiben vor Live-Nutzern offen: Erstens ist nach belastbarer
 Prüfung von fünf externen LLM-Pfaden (Azure OpenAI, Anthropic Claude API,
 Amazon Bedrock, OpenAI API, IONOS AI Model Hub) weiterhin kein
 freigabefähiger externer LLM-Providerpfad identifiziert; degraded mode ist
-kein Ersatzpilot, sondern nur Safe-/Fehlerbetrieb. Zweitens stehen die
+kein Ersatzpilot, sondern nur Safe-/Fehlerbetrieb; ein Non-LLM-Ersatzpilot
+ist im aktuellen MVP-Scope nicht entschieden. Zweitens stehen die
 Pflichtfälle der MVP-Evidence-Baseline auf dem Hetzner-Pilotpfad nicht als
 `bestanden` fest: providergekoppelte Fälle sind durch das offene
 Provider-Gate `blockiert`; nicht-providergekoppelte Fälle auf dem
 Hetzner-Pfad haben Status `Vorbedingung fehlt`. Das lokale Harness
 (`harness/`) macht bestimmte nicht-provider-gekoppelte Fälle (Gruppe A/B,
-→ PROMPT_TEST_BASELINE §3.2) lokal prüfbar, ersetzt aber keinen
-Pilot-Nachweis und stellt keine Hetzner-Runtime bereit. Bis der
-Provider-Blocker und die Hetzner-Runtime-Vorbedingungen geschlossen sind,
-bleibt der Pilot gesperrt.
+→ PROMPT_TEST_BASELINE §3.2) lokal prüfbar. Der nächste echte P0-Block ist
+jetzt `Hetzner Bootstrap Path Contract + First Evidence Recipe`: der
+vorhandene Bootstrap-Runtime-Pfad (`harness/runtime_server.py` +
+`harness/runtime_tools.py`) muss an genau einen echten Hetzner-Zielpfad
+gebunden werden, inklusive `app_root`, `workdir`, `volume_mount`, `db_path`,
+`log_path`, `pid_file`, `bind_host` und `bind_port`, und genau in der
+Sequenz `start -> health -> kurzer Session-Smoke -> inspect-db ->
+inspect-log -> inspect-sidepaths -> stop` gefahren werden. Repo-seitig ist
+der `workdir`-Contract jetzt durch den Bootstrap-Startpfad explizit
+vorbereitet; offen bleiben die echten Hetzner-Zielwerte und der erste
+Artefaktlauf. Bis die vier Artefaktklassen aus `OPERATIONS_RUNBOOK §4` für
+diesen Lauf vorliegen, bleibt der Pilot gesperrt.

--- a/knowledge/ops/OPERATIONS_RUNBOOK.md
+++ b/knowledge/ops/OPERATIONS_RUNBOOK.md
@@ -1,6 +1,6 @@
 # OPERATIONS_RUNBOOK
 
-Status: aktiv | Owner: Jannek Büngener | Zuletzt geprüft: 2026-03-27
+Status: aktiv | Owner: Jannek Büngener | Zuletzt geprüft: 2026-03-30
 
 Basis: DEPLOYMENT_ENVELOPE §2–§9, KERNEL_GUARD_CONTRACTS §3–§10,
 TEXT_FIRST_RUNTIME_FLOW §2–§8, PILOT_READINESS §3.3–§3.4,
@@ -31,18 +31,21 @@ Es beantwortet:
 
 ## 2. Aktueller Status
 
-**Hetzner-deploybare Runtime:** nicht vorhanden
-**Lokale Harness-Runtime:** vorhanden (`harness/` — Python stdlib, kein Deployment, kein Provider)
+**Bootstrap-Runtime-Pfad im Repo:** vorhanden (`harness/runtime_server.py`, `harness/runtime_tools.py`, `harness/inspect_events.py`, `harness/event_store.py`)
+**Hetzner-Zielpfadbindung und reale Evidence:** offen
 
 Der Pilotpfad (Hetzner/SQLite) ist infrastrukturell und datenschutzrechtlich
-freigegeben (PROVIDER_DPA_INPUT_MATRIX §7, DEPLOYMENT_ENVELOPE §7), aber
-nicht deployed und nicht ausführbar.
+freigegeben (PROVIDER_DPA_INPUT_MATRIX §7, DEPLOYMENT_ENVELOPE §7), aber die
+kanonische Bindung auf echte Hetzner-Zielpfade und der erste evidenzfähige Lauf
+sind noch nicht dokumentiert.
 
 Das lokale Harness (`harness/`) implementiert den kanonischen Kernel, die
 deterministischen Guards, einen content-freien SQLite-Event-Store und
-Fault-Injection-Stubs. Es ermöglicht lokale Evidence-Läufe für
-nicht-provider-gekoppelte Testfälle, ist aber kein Ersatz für den
-Hetzner-Pilotpfad und kein degraded-Mode-Pilot.
+Fault-Injection-Stubs. Zusätzlich existiert auf `main` ein minimaler
+Bootstrap-Serverprozess mit `/health` sowie Start-/Stop-/Inspect-Tooling auf
+Basis expliziter absoluter Pfade. Diese Substanz ist die operative Basis für
+den nächsten P0-Block, aber kein Ersatz für den Hetzner-Pilotpfad und kein
+degraded-Mode-Pilot.
 
 Konsequenz für PROMPT_TEST_BASELINE:
 - Nicht-provider-gekoppelte Testfälle mit lokalem Harness: Status `ausführbar`;
@@ -52,7 +55,61 @@ Konsequenz für PROMPT_TEST_BASELINE:
 - LLM-gekoppelte Testfälle (TB-2): Status `blockiert` (offenes Provider-Gate)
 
 Die §3-Punkte beziehen sich auf den Hetzner-Pilotpfad. Für lokale
-Harness-Läufe gilt §3.3/§3.8 als lokal erfüllt (smoke_check.py, fault_injection.py).
+Harness-Läufe gilt §3.3/§3.8 als lokal erfüllt (smoke_check.py,
+runtime_server.py, runtime_tools.py, fault_injection.py).
+
+### 2.1 Nächster P0-Block: Hetzner Bootstrap Path Contract + First Evidence Recipe
+
+Der nächste echte P0-Block bindet den vorhandenen Bootstrap-Pfad aus
+`harness/runtime_server.py` und `harness/runtime_tools.py` an genau einen
+realen Hetzner-Zielpfad. Konkrete Zielwerte werden hier nicht erfunden; vor dem
+ersten evidenzfähigen Lauf müssen nur die folgenden Felder kanonisch feststehen:
+
+| Feld | Minimalregel |
+|---|---|
+| `app_root` | Repo-Checkout bzw. Startwurzel des Prozesses auf dem Zielhost; der Bootstrap-Code wird von hier geladen |
+| `workdir` | explizites Arbeitsverzeichnis des Prozesses; muss beim Start gesetzt werden, ist Pflicht-Scanroot für `inspect-sidepaths` und darf nicht implizit aus `app_root` oder dem aufrufenden Shell-Kontext abgeleitet werden |
+| `volume_mount` | Root des gemounteten Hetzner Volumes |
+| `db_path` | absolute SQLite-Datei unter `volume_mount`; kein Fallback |
+| `log_path` | absoluter Host-/App-Log-Pfad; kein impliziter Workdir-Fallback |
+| `pid_file` | absoluter PID-/Metadatenpfad für `runtime_tools` |
+| `bind_host` | explizite Bind-Adresse des Runtime-Prozesses |
+| `bind_port` | expliziter Bind-Port des Runtime-Prozesses |
+
+Die erste evidenzfähige Sequenz ist genau:
+1. `start`
+2. `health`
+3. kurzer Session-Smoke
+4. `inspect-db`
+5. `inspect-log`
+6. `inspect-sidepaths`
+7. `stop`
+
+Command-first-Referenz aus `app_root`; der Laufprozess selbst arbeitet mit
+explizitem `workdir`:
+
+```bash
+python -m harness.runtime_tools start --db <db_path> --log <log_path> --pid-file <pid_file> --workdir <workdir> --host <bind_host> --port <bind_port>
+python -m harness.runtime_tools health --host <bind_host> --port <bind_port>
+curl -sS -X POST "http://<bind_host>:<bind_port>/v1/sessions" -H "Content-Type: application/json" -d "{}"
+curl -sS -X POST "http://<bind_host>:<bind_port>/v1/turns" -H "Content-Type: application/json" -d '{"session_id":"<session_id>","user_text":"ja"}'
+curl -sS -X POST "http://<bind_host>:<bind_port>/v1/turns" -H "Content-Type: application/json" -d '{"session_id":"<session_id>","user_text":"ja"}'
+python -m harness.runtime_tools inspect-db --db <db_path>
+python -m harness.runtime_tools inspect-log --log <log_path>
+python -m harness.runtime_tools inspect-sidepaths --db <db_path> --log <log_path> --pid-file <pid_file> --workdir <workdir>
+python -m harness.runtime_tools stop --pid-file <pid_file>
+```
+
+Der bei `start` gesetzte `--workdir`-Wert ist derselbe Scanroot, der bei
+`inspect-sidepaths` wiederverwendet werden muss.
+
+Der Session-Smoke ist erst dann ausreichend, wenn der zweite Opt-in-Turn den
+vorhandenen no-adapter-Pfad kontrolliert fail-closed
+(`NO_ADAPTER_CONFIGURED`) durchläuft.
+
+Dieser P0-Block ist erst geschlossen, wenn genau die vier Artefaktklassen aus
+§4 vorliegen: SQLite-Auszug, Host-Log-Ausschnitt, Sidepath-Check,
+Teststatus-Eintrag.
 
 ---
 
@@ -129,7 +186,8 @@ Für jede Testdurchführung muss nach dem Lauf prüfbar sein:
 ### 3.8 Fault-Injection-Punkte für lokale fail-closed-Fälle
 
 Die folgenden fail-closed-Fälle aus PROMPT_TEST_BASELINE (T18–T20) können ohne
-externen LLM-Provider geprüft werden, sobald die Runtime existiert:
+externen LLM-Provider lokal über den vorhandenen Harness-/Bootstrap-Pfad
+geprüft werden:
 
 | Fault-Injection | Was injiziert wird | Erwartetes Verhalten |
 |---|---|---|
@@ -213,10 +271,10 @@ starten; Befund dokumentieren; Vorbedingung schließen.
 
 | Lücke | Ursache | Konsequenz |
 |---|---|---|
-| Konkrete Startbefehle | Runtime existiert nicht; kein deployedbarer Serverprozess | §3.1–§3.3 vollständig auf `Vorbedingung fehlt` |
-| Konkrete Dateipfade auf Hetzner Volume | Kein aktiver Deploy | §3.5 vollständig auf `Vorbedingung fehlt` |
-| TTL-Purge-Verifikation | Kein laufender Prozess, kein aktiver SQLite-Store | §3.5 vollständig auf `Vorbedingung fehlt` |
-| Fault-Injection-Stub (Hetzner-Deployment) | Kein deployebarer Prozess; lokales Harness ist kein Deployment | T18–T20 im Deployment-Kontext auf `Vorbedingung fehlt`; lokal via harness/ ausführbar |
+| Kanonischer Hetzner Path Contract | Bootstrap-Serverprozess und Operator-Tooling trennen repo-seitig jetzt explizit zwischen Codepfad (`app_root`) und Laufpfad (`workdir`), aber die konkreten Zielwerte für `app_root`, `workdir`, `volume_mount`, `db_path`, `log_path`, `pid_file`, `bind_host` und `bind_port` sind auf Hetzner noch nicht festgezogen | §3.1–§3.5 auf Hetzner weiterhin `Vorbedingung fehlt` |
+| Konkrete Dateipfade auf Hetzner Volume | Kein aktiver Deploy und kein belegter `volume_mount`-/`db_path`-Wert | §3.5 vollständig auf `Vorbedingung fehlt` |
+| TTL-Purge-Verifikation | Kein laufender Hetzner-Prozess und kein aktiver Ziel-Store | §3.5 vollständig auf `Vorbedingung fehlt` |
+| Fault-Injection-Stub (Hetzner-Deployment) | Bootstrap-Prozess lokal vorhanden, aber kein an Hetzner gebundener Lauf; lokales Harness ist kein Deployment | T18–T20 im Deployment-Kontext auf `Vorbedingung fehlt`; lokal via harness/ ausführbar |
 | LLM-gekoppelte Testfälle (T01–T17) | Kein freigegebener externer LLM-Pfad (TB-2-Gate offen) | Status `blockiert` per PROMPT_TEST_BASELINE §3.1; T21 teilweise ebenfalls `blockiert` |
 | Automatisierte Testausführung | Kein CI-/Testframework vorhanden | Alle Läufe sind manuelle Review-Sessions |
 | Retention-Automatisierung auditieren | Kein laufender TTL-Purge-Job | Muss vor Pilot-Start als aktiv nachgewiesen werden |

--- a/knowledge/ops/PROMPT_TEST_BASELINE.md
+++ b/knowledge/ops/PROMPT_TEST_BASELINE.md
@@ -1,6 +1,6 @@
 # PROMPT_TEST_BASELINE
 
-Status: aktiv | Owner: Jannek Büngener | Zuletzt geprüft: 2026-03-26
+Status: aktiv | Owner: Jannek Büngener | Zuletzt geprüft: 2026-03-30
 
 Basis: GUARDRAILS_CONTENT_POLICY §2–§8, SAFETY_PLAYBOOK §3–§9,
 KERNEL_GUARD_CONTRACTS §3–§10, TEXT_FIRST_RUNTIME_FLOW §2–§6,
@@ -84,15 +84,17 @@ Ersatz.
 
 Die konkreten Vorbedingungen, Inspektionsschritte und Abbruchkriterien für
 einen evidenzfähigen Lauf auf diesem Pfad sind in `OPERATIONS_RUNBOOK §3–§6`
-beschrieben. Solange diese Vorbedingungen nicht geschlossen sind, gilt für
-alle lokal/nicht-providergekoppelten Fälle Status `Vorbedingung fehlt`.
+beschrieben. Solange diese Vorbedingungen für den Hetzner-Pilotpfad nicht
+geschlossen sind, bleiben dort nicht-providergekoppelte Fälle auf
+`Vorbedingung fehlt`; lokale Harness-/Bootstrap-Läufe ändern diesen
+Pilotstatus nicht.
 
 Jeder dokumentierte Baseline-Durchlauf muss mindestens die folgenden Felder
 führen:
 
 | Feld | Mindestinhalt |
 |---|---|
-| **Runtime-Konfiguration** | `Hetzner Cloud Server` `nbg1`, angehängtes `Hetzner Volume`, lokales `SQLite`, keine Dateifallbacks |
+| **Runtime-Konfiguration** | `Hetzner Cloud Server` `nbg1`, angehängtes `Hetzner Volume`, lokales `SQLite`, keine Dateifallbacks; Path-Contract-Felder `app_root`, `workdir`, `volume_mount`, `db_path`, `log_path`, `pid_file`, `bind_host`, `bind_port` festgezogen |
 | **Teststatus** | Genau einer von: `bestanden`, `nicht bestanden`, `blockiert`, `Vorbedingung fehlt` |
 | **Durchführungsreife** | Gibt an, ob alle Vorbedingungen für reale Ausführung vorliegen: ausführbare Runtime, definierte Start-/Stop-/Health-/Log-Inspektionspfade, reale Artefakte; bei LLM-gekoppelten Fällen zusätzlich freigegebener externer LLM-Pfad (TB-2-Gate) |
 | **Leak-/Redaction-Nachweis** | Sichtprüfung der `SQLite`-Events und der Host-Logs: kein Nutzertext, kein LLM-Output, kein Raw-Payload, keine direkte Nutzeridentität |


### PR DESCRIPTION
## Scope
- add explicit `--workdir` binding to `harness.runtime_tools start`
- persist `app_root` + `workdir` in PID metadata and start/stop output
- keep `inspect-sidepaths` aligned with the explicit scanroot contract
- tighten Canon/README wording for `Hetzner Bootstrap Path Contract + First Evidence Recipe`
- keep `harness/runtime_server.py` unchanged

## Checks Performed
- `python -m py_compile harness/runtime_tools.py harness/inspect_events.py harness/runtime_server.py`
- `python -m harness.runtime_tools start --help`
- local end-to-end run with explicit absolute paths and explicit `--workdir`:
  - `start`
  - `health`
  - short session smoke
  - `inspect-db`
  - `inspect-log`
  - `inspect-sidepaths`
  - `stop`

## Evidence
- diff scope is limited to the intended seven files
- `start` now returns and persists distinct `app_root` / `workdir`
- short smoke still fails closed on missing adapter with `NO_ADAPTER_CONFIGURED`
- `inspect-sidepaths` scanned only the explicit roots (`volume`, `workdir`, `hostlog`)
- clean stop left no `-wal` / `-shm`

## Risk / Impact
- low to medium
- startup CLI is now stricter because `--workdir` is required for `runtime_tools start`
- runtime server behavior itself is unchanged except for being launched from explicit `workdir`

## Rollback
- revert this PR to restore the previous implicit-CWD behavior in `runtime_tools start` and the prior Canon wording
