### PR TITLE
docs: provider-neutralen maintainer-only internen Testmodus kanonisch festziehen

### DIFF
--- a/knowledge/KNOWLEDGE_HUB.md
+++ b/knowledge/KNOWLEDGE_HUB.md
@@ -5,16 +5,16 @@ Kurze, belegte Entscheidungen + Links (intern) zu Evidence/Logs.
 ## Governance-Canon
 
 - [CONSTITUTION](governance/CONSTITUTION.md) – oberste, nicht verhandelbare Regeln; Prioritäten, Domain-Canon-Bindung, Änderungsschwelle
-- [GOVERNANCE](governance/GOVERNANCE.md) – Solo-Maintainer-Entscheidungsmodell, PR-Pflicht, Evidence-Schwellen, Canon-Konfliktlogik
-- [AGENT_POLICY](governance/AGENT_POLICY.md) – was KI-Agenten dürfen und nicht dürfen; Evidence-Pflicht, Eskalationsregeln
-- [GOVERNANCE_QUICKREF](governance/GOVERNANCE_QUICKREF.md) – einseitige operative Kurzreferenz
+- [GOVERNANCE](governance/GOVERNANCE.md) – Solo-Maintainer-Entscheidungsmodell, PR-Pflicht, Evidence-Schwellen, Canon-Konfliktlogik, befristeter maintainer-only interner Testmodus
+- [AGENT_POLICY](governance/AGENT_POLICY.md) – was KI-Agenten dürfen und nicht dürfen; Evidence-Pflicht, Eskalationsregeln, Grenzen des kanonisch definierten internen Testmodus
+- [GOVERNANCE_QUICKREF](governance/GOVERNANCE_QUICKREF.md) – einseitige operative Kurzreferenz inkl. roter Linien für den internen Testmodus
 - [POLICY_STACK_MINI](governance/POLICY_STACK_MINI.md) – Konflikthierarchie und Auflösungslogik
 
 ## Domain-Canon (P0-bindend)
 
 - [CLAIMS_FRAMEWORK](project/CLAIMS_FRAMEWORK.md) – Zulässige/unzulässige Claims, Red Flags, Guidance
 - [SAFETY_PLAYBOOK](project/SAFETY_PLAYBOOK.md) – Safety-Prinzipien, Exit/Safeword, Trigger-Handling, Eskalationspfade
-- [PRIVACY_BY_DESIGN](project/PRIVACY_BY_DESIGN.md) – Datenminimierung, Datenklassen, Retention, Löschung, Export, Logging-Grenzen (P0-Canon)
+- [PRIVACY_BY_DESIGN](project/PRIVACY_BY_DESIGN.md) – Datenminimierung, Datenklassen, Retention, Löschung, Export, Logging-Grenzen und Containment-Regeln für den maintainer-only internen Testmodus (P0-Canon)
 - [ARCHITECTURE_OVERVIEW](architecture/ARCHITECTURE_OVERVIEW.md) – MVP-Architektur-Canon: Kernel, Guard Layer, Adapter-Grenzen, Event-Log, fail-closed
 - [GUARDRAILS_CONTENT_POLICY](project/GUARDRAILS_CONTENT_POLICY.md) – Operative Guard-Kriterien: Input/Output-Guards, Session-Transitions, Safe-State-Mapping, Logging-Grenzen, Red-Flag-Liste
 - [KERNEL_GUARD_CONTRACTS](architecture/KERNEL_GUARD_CONTRACTS.md) – Technische Implementierungsvorlage: Zustandsmodell, Event-Contracts, Guard-Decision-Klassen, Adapter-Grenzen, fail-closed-Pfade
@@ -33,6 +33,6 @@ Kurze, belegte Entscheidungen + Links (intern) zu Evidence/Logs.
 
 - [PROJECT_META](project/PROJECT_META.md) – Projektdefinition, Nicht-Ziele, Risiken, P0/P1/P2
 - [CURRENT_STATUS](CURRENT_STATUS.md) – Aktueller Projektstand, offene Punkte, nächste Schritte
-- [SYSTEM_INVARIANTS](SYSTEM_INVARIANTS.md) – immer geltende Invarianten (Governance, Safety, Privacy, Architecture, Claims)
+- [SYSTEM_INVARIANTS](SYSTEM_INVARIANTS.md) – immer geltende Invarianten (Governance, Safety, Privacy, Architecture, Claims); interner Testmodus öffnet sie nicht
 - [SYSTEM_CONTEXT](SYSTEM.CONTEXT.md) – Umgebung, Repo-Struktur, Toolchain, Constraints
 - [ACTIVE_ROADMAP](ACTIVE_ROADMAP.md) – Now / Next / Later

--- a/knowledge/SYSTEM_INVARIANTS.md
+++ b/knowledge/SYSTEM_INVARIANTS.md
@@ -1,6 +1,6 @@
 # SYSTEM_INVARIANTS – Traumtänzer
 
-Status: aktiv | Owner: Jannek Büngener | Zuletzt geprüft: 2026-03-25
+Status: aktiv | Owner: Jannek Büngener | Zuletzt geprüft: 2026-04-03
 
 Invarianten gelten immer. Sie sind nicht verhandelbar und werden nicht durch Operative Defaults oder Session-Absprachen außer Kraft gesetzt. Bei Konflikt mit einer Invariante gilt: Canon prüfen, nicht Invariante ignorieren.
 
@@ -48,6 +48,11 @@ Technische Logs enthalten keine Nutzertexte, keine Session-Inhalte, keine Auslö
 
 **P-4: Kein Provider-Einsatz ohne geprüften DPA.**
 Keine Produktionsnutzung personenbezogener Daten mit externen Diensten, solange Datenverarbeitungsvertrag nicht geprüft und dokumentiert ist.
+
+Der kanonisch definierte provider-neutrale maintainer-only interne Testmodus
+öffnet diese Invarianten nicht. Er ist kein Pilotpfad, kein Live-Pfad und kein
+Provider-Go; Detailregeln zu Scope, Containment und Traceability stehen in
+`GOVERNANCE.md` und `PRIVACY_BY_DESIGN.md`.
 
 ---
 

--- a/knowledge/governance/AGENT_POLICY.md
+++ b/knowledge/governance/AGENT_POLICY.md
@@ -1,6 +1,6 @@
 # AGENT_POLICY – Traumtänzer
 
-Status: aktiv | Owner: Jannek Büngener | Zuletzt geprüft: 2026-03-25
+Status: aktiv | Owner: Jannek Büngener | Zuletzt geprüft: 2026-04-03
 
 ---
 
@@ -56,6 +56,17 @@ Agenten liefern Zuarbeit. Der Owner entscheidet. Kein Merge, kein produktrelevan
 **Kein Weichreden, was hart geregelt ist.**
 Wenn Canon eine Grenze setzt, formuliert der Agent keine Umgehung und keine Ausnahme. Er benennt die Grenze und eskaliert, wenn nötig.
 
+**Kanonisch definierter interner Testmodus nur innerhalb enger Grenzen.**
+Wenn `GOVERNANCE.md` und `PRIVACY_BY_DESIGN.md` einen provider-neutralen
+maintainer-only internen Testmodus kanonisch definieren, dürfen Agenten ihn
+benennen, dokumentieren und innerhalb dieser Grenzen anwenden. Das ist keine
+allgemeine Test-Ausnahme.
+
+- Verboten bleiben jede Ausweitung zu Pilot oder Live-Nutzung.
+- Verboten bleibt jede Interpretation als Provider-Go.
+- Verboten bleiben Drittrohmaterial, Content-Logging und Spiegelung in Repo,
+  Tickets, Logs, Screenshots, Testfixtures oder anderen Side-Artefakten.
+
 ---
 
 ## 5. Evidence-Pflicht
@@ -79,6 +90,7 @@ Agenten eskalieren an den Owner, wenn:
 
 - ein Canon-Konflikt nicht eindeutig auflösbar ist
 - eine Anfrage Safety- oder Privacy-Grenzen berührt
+- eine Anfrage den kanonisch definierten internen Testmodus über seine engen Grenzen hinaus ausweiten würde
 - eine Änderung Auswirkungen über den aktuellen Scope hinaus hat
 - die korrekte Vorgehensweise unklar ist
 

--- a/knowledge/governance/GOVERNANCE.md
+++ b/knowledge/governance/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # GOVERNANCE – Traumtänzer
 
-Status: aktiv | Owner: Jannek Büngener | Zuletzt geprüft: 2026-03-25
+Status: aktiv | Owner: Jannek Büngener | Zuletzt geprüft: 2026-04-03
 
 ---
 
@@ -61,7 +61,28 @@ Evidence Pack bedeutet: was wurde geprüft, warum ist die Entscheidung sicher, w
 
 ---
 
-## 5. Canon-Konflikte
+## 5. Befristeter maintainer-only interner Testmodus
+
+Ein provider-neutraler maintainer-only interner Testmodus ist nur als enge,
+befristete Canon-Regel zulässig. Er gilt nur auf einem kontrollierten
+Systempfad, nur für maintainer-only interne Läufe und erzeugt nur interne
+System-Evidence. Er ist kein Pilot-Go, kein Live-Go und kein Provider-Go.
+
+Einführung, Verlängerung und Aufhebung dieses Modus erfolgen ausschließlich via
+PR auf `main` mit Evidence Pack und explizitem Befristungs- oder Review-Hinweis.
+Informelle Session-Absprachen ersetzen diese Canon-Entscheidung nicht.
+
+Jeder Lauf in diesem Modus braucht minimale, content-freie Traceability im
+zugehörigen Issue oder PR:
+
+- Zweck
+- erwarteter Erkenntnisgewinn
+- kurzer Befund
+- Löschhinweis
+
+---
+
+## 6. Canon-Konflikte
 
 Wenn zwei Canon-Dokumente widersprüchliche Regeln enthalten:
 
@@ -74,7 +95,7 @@ Kein Merge „weil es sich okay anfühlt". Kein Merge, der einen Konflikt verdec
 
 ---
 
-## 6. Sauberer Session-Abschluss
+## 7. Sauberer Session-Abschluss
 
 Eine Arbeits-Session mit KI-Agenten gilt als abgeschlossen, wenn:
 
@@ -88,7 +109,7 @@ Eine Arbeits-Session mit KI-Agenten gilt als abgeschlossen, wenn:
 
 ---
 
-## 7. Branch-Strategie
+## 8. Branch-Strategie
 
 - `main` – geschützt, PR-only, CI-Pflicht
 - Feature-/Docs-Branches: `docs/`, `feat/`, `fix/` – kurzlebig, kleiner Scope
@@ -96,7 +117,7 @@ Eine Arbeits-Session mit KI-Agenten gilt als abgeschlossen, wenn:
 
 ---
 
-## 8. Was nicht erfunden wird
+## 9. Was nicht erfunden wird
 
 - keine Review-Gremien, die nicht existieren
 - keine Approval-Chains ohne reale Personen dahinter

--- a/knowledge/governance/GOVERNANCE_QUICKREF.md
+++ b/knowledge/governance/GOVERNANCE_QUICKREF.md
@@ -25,6 +25,18 @@ Einseitige operative Kurzreferenz. Kein Ersatz für die vollständigen Dokumente
 
 ---
 
+## Interner Testmodus (eng)
+
+- interner Testmodus != Pilot
+- interner Testmodus != Live
+- interner Testmodus != Provider-Freigabe
+- nur maintainer-only auf kontrolliertem Systempfad
+- keine Spiegelung in Repo, Tickets, Logs, Screenshots oder Testfixtures
+- lokale Rohablage nur eng begrenzt; max. 7 Tage, dann löschen
+- pro Lauf nur minimale content-freie Traceability: Zweck, erwarteter Erkenntnisgewinn, kurzer Befund, Löschhinweis
+
+---
+
 ## Sauberer Session-Abschluss
 
 - [ ] Dateien committed und gepusht

--- a/knowledge/project/PRIVACY_BY_DESIGN.md
+++ b/knowledge/project/PRIVACY_BY_DESIGN.md
@@ -1,6 +1,6 @@
 # PRIVACY_BY_DESIGN
 
-Status: aktiv | Owner: Jannek Büngener | Zuletzt geprüft: 2026-03-26
+Status: aktiv | Owner: Jannek Büngener | Zuletzt geprüft: 2026-04-03
 
 ---
 
@@ -68,6 +68,23 @@ Nichts wird persistiert, solange kein konkreter, minimaler Zweck vorliegt. Im Zw
 - Session-Inhalte (Nutzereingaben, KI-Antworten in der Session) sind ephemer: sie existieren nur während der aktiven Session.
 - Nach Session-Ende: kein automatisches Persistieren von Inhalten.
 - Wenn Nutzer eine Speicherung wünscht (z. B. eigenes Journal): explizites Opt-in erforderlich, technische Umsetzung noch zu definieren.
+
+### Enger maintainer-only interner Testmodus
+
+Der provider-neutrale maintainer-only interne Testmodus ist kein allgemeiner
+Privacy-Override, sondern ein eng begrenzter Sonderpfad für interne Systemtests
+auf einem kontrollierten Systempfad. Die Privacy-Defaults dieses Dokuments
+bleiben für alle anderen Pfade unverändert.
+
+- Nur maintainer-only; keine Pilot- oder Live-Nutzung.
+- Nur kontrollierter Systempfad; keine Nebenpfade, keine Schattenablage, kein Schattenbetrieb.
+- Eigenes Material des Maintainers ist zulässig.
+- Material mit Drittbezug darf nur vorab abstrahiert, entschärft oder entfernt genutzt werden; kein Drittrohmaterial.
+- Lokale Rohablage ist nur eng begrenzt zulässig, wenn sie für den konkreten Testlauf notwendig ist; maximale Haltedauer: 7 Tage.
+- Für solche lokal abgelegten Rohinhalte besteht explizite Löschpflicht; stilles Liegenlassen ist kein zulässiger Default.
+- Verboten ist jede Spiegelung in Repo, Tickets, Logs, Screenshots, Testfixtures, Beispieldaten oder sonstigen Nebenartefakten.
+- Die pro Lauf geforderte Traceability bleibt content-frei und enthält keinen Rohinhalt.
+- Der Modus erzeugt nur interne System-Evidence; er begründet weder Pilot-Go noch Live-Go noch Provider-Freigabe.
 
 ### Logs
 


### PR DESCRIPTION
## Ziel
Den provider-neutralen maintainer-only internen Testmodus als engen Canon-Pfad festziehen, ohne Pilot-, Live- oder Provider-Gates aufzuweichen.

## Was geändert wurde
- `knowledge/governance/GOVERNANCE.md`: formale, befristete Sonderregel für den Modus mit PR-/Evidence-Bindung und minimaler content-freier Lauf-Traceability in Issue oder PR
- `knowledge/project/PRIVACY_BY_DESIGN.md`: Primärabschnitt für Daten- und Containment-Logik des Modus
- `knowledge/SYSTEM_INVARIANTS.md`: enge Klarstellung, dass der Modus keine Invarianten öffnet
- `knowledge/governance/AGENT_POLICY.md`: Spiegelung der Agenten-Grenzen für den kanonisch definierten Modus
- `knowledge/governance/GOVERNANCE_QUICKREF.md`: operative Kurzreferenz für die roten Linien des Modus
- `knowledge/KNOWLEDGE_HUB.md`: Navigation und Kurzbeschreibung nachgezogen

## Was bewusst nicht geändert wurde
- keine neue Statuslogik neben `PROVIDER_DPA_INPUT_MATRIX.md` oder `PILOT_READINESS.md`
- keine allgemeine Aufweichung von Privacy-by-Default, Ephemeralität oder Content-Logging
- keine Änderungen an `knowledge/project/PROJECT_META.md`
- keine Übernahme von `.claude/settings.local.json`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` oder `knowledge/ops/HETZNER_SQLITE_EVIDENCE_DELTA_PLAN.md`

## Validierung
- gegen `knowledge/governance/CONSTITUTION.md` gegengelesen
- gegen `knowledge/project/PROVIDER_DPA_INPUT_MATRIX.md` gegengelesen
- gegen `knowledge/ops/PILOT_READINESS.md` gegengelesen
- Mini-Härtung in `GOVERNANCE.md`: Lauf-Traceability fail-closed auf `Issue oder PR` verengt
- cached diff vor Commit strikt auf die sechs #68-Dateien begrenzt

## Offene Restpunkte
- keine fachlichen Restpunkte im Patch selbst
- operativ darf der Commit nur die sechs #68-Dateien enthalten