### PR TITLE
docs: OpenAI-Status und Statusdokumente auf internen Testmodus spiegeln

### DIFF
--- a/knowledge/ACTIVE_ROADMAP.md
+++ b/knowledge/ACTIVE_ROADMAP.md
@@ -1,6 +1,6 @@
 # ACTIVE_ROADMAP
 
-Stand: 2026-03-27 – synchronisiert mit `main` (nach gemergter Docs-/Spec-Kette bis PR #42)
+Stand: 2026-04-03 – gespiegelt auf den aktuellen Canon-Stand inkl. interner Testmodus-Basis
 
 ---
 
@@ -26,14 +26,16 @@ Stand: 2026-03-27 – synchronisiert mit `main` (nach gemergter Docs-/Spec-Kette
 
 ## Now
 
-- **Kein freigabefähiger externer LLM-Pfad** (P0-Blocker vor Live-Nutzer): fünf Pfade bewertet (Azure OpenAI, Anthropic Claude API, Amazon Bedrock, OpenAI API, IONOS AI Model Hub) – keiner `zulässig für Pilot`; Provider-Gate bleibt offen
+- **Kein freigabefähiger externer LLM-Pfad** (P0-Blocker vor Live-Nutzer): fünf Pfade bewertet (Azure OpenAI, Anthropic Claude API, Amazon Bedrock, OpenAI API, IONOS AI Model Hub) – keiner `zulässig für Pilot`; OpenAI bleibt im Standardpfad `nicht zulässig für Live-Nutzer`; Provider-Gate bleibt offen
 - **Degraded mode ist kein Ersatzpilot**: degraded mode ist ausschließlich Safe-/Fehlerbetrieb; Live-Pilot nur mit freigegebenem externem LLM-Pfad
+- **Provider-neutraler maintainer-only interner Testmodus ist nur Arbeitsmodus**: befristeter Aufbaupfad auf kontrolliertem Systempfad für interne System-Evidence; kein Pilot, kein Live-Pfad und kein Provider-Go
 - **Lokales Harness vorhanden** (`harness/`): Kernel-Zustandsmaschine, deterministische Guards, content-freier SQLite-Event-Store, Stub-Adapter, Fault-Injection, Smoke-Check und Szenarien-Runner implementiert; nicht-provider-gekoppelte Testfälle lokal ausführbar; Hetzner-deploybare Runtime fehlt weiterhin; Vorbedingungsliste für Hetzner-Pfad in `OPERATIONS_RUNBOOK §3`; provider-gekoppelte Pflichtfälle bleiben `blockiert`
 
 ---
 
 ## Next
 
+- Interne Testläufe nur zur System-/Containment-Evidence nutzen und strikt getrennt von Pilot-/Provider-Freigabe halten; das offene Provider-Gate bleibt eigene P0-Lücke
 - Export-/IAM-Pfad nur bei echtem Persistenzbedarf konkretisieren
 - Non-LLM-MVP nur falls separat entschieden: eigener Scope, kein Fallback des aktuellen Piloten und keine Voraussetzung für Pilotfreigabe im aktuellen Rahmen
 

--- a/knowledge/CURRENT_STATUS.md
+++ b/knowledge/CURRENT_STATUS.md
@@ -1,18 +1,21 @@
 # CURRENT_STATUS – Traumtänzer
 
-Zuletzt aktualisiert: 2026-03-27
+Zuletzt aktualisiert: 2026-04-03
 
 ---
 
 ## Aktueller Stand
 
 **Branch:** `main`
-**PRs:** Docs-/Spec- und Sync-PRs bis #56 gemergt – Canon-Grundstock,
-Provider- und Infrastrukturentscheide auf `main`
+**PRs:** Docs-/Spec-, Provider- und Infrastruktur-Canon liegen vor; der
+provider-neutrale maintainer-only interne Testmodus ist als befristeter
+Canon-Arbeitsmodus definiert
 **Phase:** Core-Canon, Providerprüfung (fünf externe LLM-Pfade bewertet:
 Azure OpenAI, Anthropic Claude API, Amazon Bedrock, OpenAI API, IONOS AI
-Model Hub – keiner freigabefähig), Pilot-Infrastrukturpfad und die auf die
-konkrete Zielumgebung gespiegelt definierte MVP-Evidence-Baseline stehen; die
+Model Hub – keiner freigabefähig), befristeter provider-neutraler
+maintainer-only interner Testmodus nur für interne System-Evidence auf
+kontrolliertem Systempfad, Pilot-Infrastrukturpfad und die auf die konkrete
+Zielumgebung gespiegelt definierte MVP-Evidence-Baseline stehen; die
 dokumentierte reale Durchführung der Pflichtfälle steht insgesamt aus –
 nicht-providergekoppelte Fälle mangels Runtime-/Deploy-/Runbook-Substanz
 als `Vorbedingung fehlt`, providergekoppelte Fälle durch das offene
@@ -72,8 +75,8 @@ nur Safe-/Fehlerbetrieb
 
 | Punkt | Priorität | Referenz |
 |---|---|---|
-| Nach Bewertung von Azure OpenAI, Anthropic Claude API (`/v1/messages`), Amazon Bedrock (`InvokeModel` + `anthropic.claude-sonnet-4-6`), OpenAI API (`eu.api.openai.com`, `POST /v1/chat/completions`) und IONOS AI Model Hub (`POST /v1/chat/completions`) ist aktuell kein externer LLM-Pfad freigabefähig; produktnahe Subprocessor-, Löschpfad- und Side-Artifact-Blocker bleiben live-relevant | P0 vor Live-Nutzer | PROVIDER_DPA_INPUT_MATRIX §7–§8 |
-| Die minimale Red-Team-/Prompt-Testbaseline ist auf den freigegebenen Pilotpfad gespiegelt; dokumentierte Pflichtnachweise sind definiert; providergekoppelte Fälle sind `blockiert` (kein freigegebener LLM-Pfad); auf dem Hetzner-Pilotpfad verbleiben nicht-providergekoppelte Fälle auf `Vorbedingung fehlt`; im lokalen Harness sind bestimmte Fälle (Gruppen A/B) prüfbar (→ PROMPT_TEST_BASELINE §3.2); degraded mode ist kein Ersatzpilot | P0 vor Live-Nutzer | PROMPT_TEST_BASELINE §3.1–§3.2, PILOT_READINESS §3.3 |
+| Nach Bewertung von Azure OpenAI, Anthropic Claude API (`/v1/messages`), Amazon Bedrock (`InvokeModel` + `anthropic.claude-sonnet-4-6`), OpenAI API (`eu.api.openai.com`, `POST /v1/chat/completions`) und IONOS AI Model Hub (`POST /v1/chat/completions`) ist aktuell kein externer LLM-Pfad freigabefähig; OpenAI bleibt im Standardpfad `nicht zulässig für Live-Nutzer`; produktnahe Subprocessor-, Löschpfad- und Side-Artifact-Blocker bleiben live-relevant | P0 vor Live-Nutzer | PROVIDER_DPA_INPUT_MATRIX §7–§8 |
+| Die minimale Red-Team-/Prompt-Testbaseline ist auf den freigegebenen Pilotpfad gespiegelt; dokumentierte Pflichtnachweise sind definiert; providergekoppelte Fälle sind `blockiert` (kein freigegebener LLM-Pfad); auf dem Hetzner-Pilotpfad verbleiben nicht-providergekoppelte Fälle auf `Vorbedingung fehlt`; im lokalen Harness sind bestimmte Fälle (Gruppen A/B) prüfbar (→ PROMPT_TEST_BASELINE §3.2); maintainer-only interne Testläufe auf kontrolliertem Systempfad können nur interne System-Evidence erzeugen und zählen nicht als Pilot- oder Provider-Freigabe-Evidence; degraded mode ist kein Ersatzpilot | P0 vor Live-Nutzer | PROMPT_TEST_BASELINE §3.1–§3.2, PILOT_READINESS §3.3 |
 | Lokales Harness (`harness/`) vorhanden: Kernel, Guards, Stub-Adapter, content-freier SQLite-Event-Store, Fault-Injection, Smoke-Check und Szenarien-Runner; Fallgruppen-Mapping gegen Baseline in PROMPT_TEST_BASELINE §3.2 dokumentiert; Hetzner-deploybare Runtime fehlt weiterhin; lokale Harness-Artefakte sind kein Pilot-Nachweis; konkrete Hetzner-Vorbedingungen in OPERATIONS_RUNBOOK §3 | P0 vor Evidence-Ausführung (Hetzner-Pfad) | PROMPT_TEST_BASELINE §3.2, OPERATIONS_RUNBOOK §3–§9 |
 | Externe Ressourcenliste über Deutschland hinaus erweitern | bei Produktisierung | SAFETY_PLAYBOOK §7 |
 
@@ -94,4 +97,6 @@ Hetzner-Pfad haben Status `Vorbedingung fehlt`. Das lokale Harness
 → PROMPT_TEST_BASELINE §3.2) lokal prüfbar, ersetzt aber keinen
 Pilot-Nachweis und stellt keine Hetzner-Runtime bereit. Bis der
 Provider-Blocker und die Hetzner-Runtime-Vorbedingungen geschlossen sind,
-bleibt der Pilot gesperrt.
+bleibt der Pilot gesperrt. Der provider-neutrale maintainer-only interne
+Testmodus kann Systemaufbau und interne System-Evidence stützen, schließt aber
+keinen dieser P0-Blocker und ersetzt weder Pilot- noch Provider-Freigabe.

--- a/knowledge/ops/PILOT_READINESS.md
+++ b/knowledge/ops/PILOT_READINESS.md
@@ -1,6 +1,6 @@
 # PILOT_READINESS
 
-Status: aktiv | Owner: Jannek Büngener | Zuletzt geprüft: 2026-03-26
+Status: aktiv | Owner: Jannek Büngener | Zuletzt geprüft: 2026-04-03
 
 Basis: CLAIMS_FRAMEWORK, SAFETY_PLAYBOOK, PRIVACY_BY_DESIGN, ARCHITECTURE_OVERVIEW,
 UX_CORE_SEQUENCE, GUARDRAILS_CONTENT_POLICY, SYSTEM_INVARIANTS
@@ -55,7 +55,7 @@ Es gilt vor dem ersten Nutzerkontakt. Bei Erfüllung aller Voraussetzungen darf 
 | Input-Guards für Safeword und Krisensprache operativ | Abdeckung jeder denkbaren Formulierungsvariante | Safeword oder Krisensprache werden nicht erkannt |
 | Output-Guards-Kriterien definiert und angewandt | Automatisierte Prüfung jedes Outputs | Diagnose-, Therapie- oder Companion-Outputs werden nicht geblockt |
 | fail-closed-Verhalten bei Guard-Unsicherheit sowie Guard-, Adapter- und Provider-Output-Fehlerpfaden definiert | Vollständige Guard-Testabdeckung | Kein definiertes Verhalten bei Guard-Unsicherheit oder fehlerhaftem Provider-Output |
-| `PROMPT_TEST_BASELINE.md` als minimale Evidence-Baseline vorhanden; vor Pilotstart sind alle P0-Fälle sowie Leak-/fail-closed-/sidepath-Fälle gegen den freigegebenen Pilotpfad (`Hetzner Cloud Server` `nbg1` + `Hetzner Volume` + lokales `SQLite`) dokumentiert `bestanden`, und kein providergekoppelter Pflichtfall steht auf `blockiert`; `blockiert` ist für providergekoppelte Fälle bei offenem externem LLM-Gate reserviert; nicht-providergekoppelte Fälle ohne ausführbare Runtime, definierte Start-/Stop-/Health-/Log-Inspektionspfade und reale Artefakte stehen auf `Vorbedingung fehlt` – dieser Status ist kein `bestanden`; ein benannter Hetzner-/SQLite-Pilotpfad allein reicht nicht für evidenzfähige reale Durchführung | Vollständige Automatisierung, Fuzzing oder Langzeit-Drift-Tests | Keine minimale Red-Team-/Prompt-Testbaseline oder kein Nachweis für Krisen-, Boundary-, Companion-, Leak-, Sidepath- und fail-closed-Pfade gegen den freigegebenen Pilotpfad |
+| `PROMPT_TEST_BASELINE.md` als minimale Evidence-Baseline vorhanden; vor Pilotstart sind alle P0-Fälle sowie Leak-/fail-closed-/sidepath-Fälle gegen den freigegebenen Pilotpfad (`Hetzner Cloud Server` `nbg1` + `Hetzner Volume` + lokales `SQLite`) dokumentiert `bestanden`, und kein providergekoppelter Pflichtfall steht auf `blockiert`; `blockiert` ist für providergekoppelte Fälle bei offenem externem LLM-Gate reserviert; nicht-providergekoppelte Fälle ohne ausführbare Runtime, definierte Start-/Stop-/Health-/Log-Inspektionspfade und reale Artefakte stehen auf `Vorbedingung fehlt` – dieser Status ist kein `bestanden`; ein benannter Hetzner-/SQLite-Pilotpfad allein reicht nicht für evidenzfähige reale Durchführung; maintainer-only interne Testläufe auf kontrolliertem Systempfad erzeugen nur interne System-Evidence und zählen nicht als `bestanden` oder Pilot-Nachweis für diesen Pfad | Vollständige Automatisierung, Fuzzing oder Langzeit-Drift-Tests | Keine minimale Red-Team-/Prompt-Testbaseline oder kein Nachweis für Krisen-, Boundary-, Companion-, Leak-, Sidepath- und fail-closed-Pfade gegen den freigegebenen Pilotpfad |
 
 ### 3.4 Privacy- und Retention-Grundlagen
 
@@ -67,7 +67,7 @@ Es gilt vor dem ersten Nutzerkontakt. Bei Erfüllung aller Voraussetzungen darf 
 | Löschpfad konzeptuell definiert | Vollständige DPIA | Kein definierter Löschpfad |
 | Zielkomponente für Event-Storage/Logs ist konkret benannt; 90-/30-Tage-Retention, automatische Löschung und Backup-/Nebenlogik dieses Pfads sind technisch belastbar beschrieben | Vollständige Audit-/Observability-Infrastruktur | Offener Event-Storage-/Hosting-Pfad oder nur behauptetes Retention-Enforcement |
 | Pilot-Teilnehmer wissen, dass das System KI-gestützt ist und welche Daten verarbeitet werden | Vollständige Datenschutzerklärung in Endform | Keine Information der Teilnehmer über Datenverarbeitung |
-| Kein Live-Nutzer mit externen Providern ohne ausgefüllte und positiv bewertete `PROVIDER_DPA_INPUT_MATRIX.md` | Vollständige juristische Endprüfung aller Verträge | Personenbezogene Daten fließen an einen Provider mit offener Matrix oder negativem Entscheidungsstatus |
+| Kein Live-Nutzer mit externen Providern ohne ausgefüllte und positiv bewertete `PROVIDER_DPA_INPUT_MATRIX.md`; maintainer-only interne Testläufe oder interne System-Evidence ersetzen weder positive Matrix noch Provider-Freigabe | Vollständige juristische Endprüfung aller Verträge | Personenbezogene Daten fließen an einen Provider mit offener Matrix oder negativem Entscheidungsstatus |
 | Retention, Training/Service-Verbesserung, Region/Transfer und Subprocessor-Lage des konkreten Produktpfads sind geklärt | Vollständige Vertragsarchivierung im Endzustand | Ungeklärte Retention-, Training-, Region- oder Subprocessor-Lage |
 
 **Aktueller Pilotpfad (Entscheid 2026-03-26):**
@@ -80,6 +80,13 @@ Es gilt vor dem ersten Nutzerkontakt. Bei Erfüllung aller Voraussetzungen darf 
 - Zusatzbedingungen: keine Server-Backups, keine Snapshots, keine externen
   Log-/Storage-Replikate; täglicher TTL-Purge + `VACUUM`; Host-Logs bleiben
   content-free und max. 30 Tage
+
+**Explizite Abgrenzung zum internen Testmodus:**
+Maintainer-only interne Testläufe nach `GOVERNANCE.md §5` und
+`PRIVACY_BY_DESIGN.md §2` sind kein Pilotpfad. Auch mit realem Eigenmaterial
+erzeugen sie nur interne System-Evidence; sie zählen weder als
+Pilot-Nachweis noch als Provider-Freigabe-Evidence und ändern keine negative
+Matrixbewertung.
 
 ### 3.5 Kernel- und Safe-State-Disziplin
 
@@ -129,6 +136,7 @@ Wenn auch nur eine dieser Bedingungen zutrifft: **kein Pilotstart**.
 | 13 | Kein definiertes Verhalten bei Safety-Ereignis (kein Safe State, kein fail-closed) |
 | 14 | Pilot-Teilnehmer wissen nicht, dass sie mit einem KI-System interagieren |
 | 15 | Keine minimale Red-Team-/Prompt-Testbaseline oder kein Nachweis für Safeword-, Krisen-, Boundary-, Companion-, Leak-, Sidepath- und fail-closed-Pfade gegen den freigegebenen Pilotpfad |
+| 16 | Maintainer-only interne Testläufe oder interne System-Evidence werden als Pilot-Nachweis oder Ersatz für positive Provider-Matrix behandelt |
 
 ---
 

--- a/knowledge/project/PROJECT_META.md
+++ b/knowledge/project/PROJECT_META.md
@@ -7,6 +7,7 @@
   - Keine autoritäre „Traumdeutung als Wahrheit“; nur Hypothesen/Fragen/Erlebnis.
   - Kein manipulativer Companion/Bindungs‑Design; keine Abhängigkeitsmechaniken.
   - Kein datenhungriges Tracking; Datenminimierung/Privacy-by-Default.
+  - Kein Ersatzpilot über maintainer-only internen Testbetrieb; Live-Pilot nur mit freigegebenem externem LLM-Pfad.
 - Owner: Jannek Büngener
 - Risiken:
   - Trigger-/Belastungsrisiko (Trauma, Dissoziation, Realitätsdrift) → Exit/Safeword/Notfall-Flow.
@@ -18,6 +19,6 @@
   - P0: Claim-Framework (Do/Don’t-Claims) + Nicht‑Therapie‑Positionierung schriftlich fixiert.
   - P0: Privacy-by-Design Paket (DPIA Draft, Retention, Export/Löschung, Subprozessor-Liste).
   - P0: Safety Playbook (Exit/Safeword, Trigger-Handling, Notfall-Templates, Escalation Path).
-  - P1: UX‑Prototyp „Sanfte Begegnung“ (Entry → Szene → Exit) + kleine Pilotgruppe (30–60).
+  - P1: UX‑Prototyp „Sanfte Begegnung“ (Entry → Szene → Exit) + kleine Pilotgruppe (30–60), aber nur mit freigegebenem externem LLM-Pfad; maintainer-only interner Testbetrieb ist kein Ersatzpilot.
   - P1: Guardrails/Content Policy (keine Diagnosen, keine absoluten Deutungen, keine Manipulation).
   - P2: Light/Core Pricing & Packaging (Light kostenlos, Core ca. 39€/Monat als Hypothese) validiert.

--- a/knowledge/project/PROVIDER_DPA_INPUT_MATRIX.md
+++ b/knowledge/project/PROVIDER_DPA_INPUT_MATRIX.md
@@ -1,6 +1,6 @@
 # PROVIDER_DPA_INPUT_MATRIX
 
-Status: aktiv | Owner: Jannek Büngener | Zuletzt geprüft: 2026-03-26
+Status: aktiv | Owner: Jannek Büngener | Zuletzt geprüft: 2026-04-03
 
 Basis: PRIVACY_BY_DESIGN §2, §5, §6, §9; DEPLOYMENT_ENVELOPE §4–§7;
 PILOT_READINESS §3.4, §8; SYSTEM_INVARIANTS P-1–P-4, A-4
@@ -389,8 +389,18 @@ Console-/Support-/Debug-Nutzung als Produktbestandteil.
   Backup-/Replikationsreste bleibt offen.
 - DPA-Abdeckung für den EU-Residency-Pfad ohne aktives MAM/ZDR ist
   nicht belastbar geschlossen.
+- Für den aktuellen MVP zählt nur dieser dokumentierte Standardpfad
+  (`eu.api.openai.com` + `POST /v1/chat/completions`) als
+  Bewertungsmaßstab; approval-/sales-gesteuerte MAM-/ZDR-Sonderpfade
+  sind ohne bereits aktivierte, belastbar belegte Sondervereinbarung
+  kein belastbarer MVP-Standardkandidat.
 
 **Operativer Entscheid:** `nicht zulässig für Live-Nutzer`
+
+Ein separater provider-neutraler maintainer-only interner Testmodus nach
+`GOVERNANCE.md §5` und `PRIVACY_BY_DESIGN.md §2` kann OpenAI nur als internen
+Arbeitsmotor auf kontrolliertem Systempfad zulassen; er ändert weder diese
+Live-Ampel noch eine Pilot- oder Provider-Freigabe.
 
 #### F. IONOS AI Model Hub – `openai.inference.de-txl.ionos.com` Pfad
 


### PR DESCRIPTION
## Ziel
Die Leitentscheidung zu OpenAI und zum engen internen Testmodus in Matrix-, Status-, Roadmap-, Meta- und Pilotdokumente spiegeln, ohne Pilot-, Live- oder Provider-Gates aufzuweichen.

## Was geändert wurde
- `knowledge/project/PROVIDER_DPA_INPUT_MATRIX.md`: OpenAI bleibt klar `nicht zulaessig fuer Live-Nutzer`; Standardpfad zählt; Sonderpfade sind kein belastbarer MVP-Standardkandidat; interner Testmodus ändert die Live-Ampel nicht
- `knowledge/CURRENT_STATUS.md`: interner Testmodus als befristeter Arbeitsmodus gespiegelt; klare Trennung zwischen interner System-Evidence und Live-/Pilot-/Provider-Freigabe
- `knowledge/ACTIVE_ROADMAP.md`: interner Testmodus als Aufbaupfad sichtbar gemacht, ohne das offene Provider-Gate zu ersetzen
- `knowledge/project/PROJECT_META.md`: Live-Pilot weiter nur mit freigegebenem externem LLM-Pfad; interner Testbetrieb bleibt separat
- `knowledge/ops/PILOT_READINESS.md`: interne maintainer-only Testläufe explizit nicht als Pilot- oder Provider-Evidence lesbar

## Was bewusst nicht geändert wurde
- keine technische OpenAI-Integration
- keine Neubewertung anderer Provider
- keine allgemeine Aufweichung des Live-Gates
- keine neue Canon-Logik für den internen Testmodus
- keine Vermischung mit scopefremden Dateien

## Validierung
- gegen Issue #59 gegengelesen
- gegen #68 / PR #70 gegengelesen
- keine zweite Statuslogik eingeführt
- kein Pilot-Go, Live-Go oder Provider-Go impliziert
- cached diff strikt auf die fünf #69-Dateien begrenzt

## Offene Restpunkte
- keine fachlichen Restpunkte im Patch selbst, sofern #68 / PR #70 als Canon-Basis sauber verfügbar ist
- falls #70 noch nicht gemergt ist, bleibt die Abhängigkeit explizit sichtbar